### PR TITLE
feat: add Result to ProblemDetails.Abstractions

### DIFF
--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ErrorCode.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ErrorCode.cs
@@ -10,7 +10,7 @@ namespace Altinn.Authorization.ProblemDetails;
 /// <summary>
 /// An unique error code that identifies a specific error.
 /// </summary>
-[DebuggerDisplay("{DebuggerDisplay,nq}")]
+[DebuggerDisplay("{_value,nq}")]
 [JsonConverter(typeof(ErrorCodeJsonConverter))]
 public readonly struct ErrorCode
     : IEquatable<ErrorCode>
@@ -74,19 +74,6 @@ public readonly struct ErrorCode
     /// <inheritdoc/>
     public string ToString(string? format, IFormatProvider? formatProvider)
         => _value ?? string.Empty;
-
-    private string DebuggerDisplay
-    {
-        get
-        {
-            if (_value is null)
-            {
-                return "null";
-            }
-
-            return $"\"{_value}\"";
-        }
-    }
 
     /// <inheritdoc/>
     public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ProblemDescriptor.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ProblemDescriptor.cs
@@ -8,7 +8,7 @@ namespace Altinn.Authorization.ProblemDetails;
 /// An immutable descriptor for a problem.
 /// </summary>
 [DebuggerDisplay("{ErrorCode,nq}: {Detail,nq}")]
-public sealed class ProblemDescriptor
+public sealed record class ProblemDescriptor
 {
     /// <summary>
     /// Gets the error code.

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ProblemExtensionData.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ProblemExtensionData.cs
@@ -1,0 +1,577 @@
+﻿using CommunityToolkit.Diagnostics;
+using System.Buffers;
+using System.Collections;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace Altinn.Authorization.ProblemDetails;
+
+/// <summary>
+/// Extensions for <see cref="ProblemInstance"/>s and <see cref="ValidationErrorInstance"/>s.
+/// </summary>
+[DebuggerDisplay("Count = {DebuggerLength}")]
+[DebuggerTypeProxy(typeof(ProblemExtensionDataDebuggerProxy))]
+[CollectionBuilder(typeof(ProblemExtensionData), nameof(Create))]
+public readonly struct ProblemExtensionData
+    : IEnumerable<KeyValuePair<string, string>>
+    , IReadOnlyCollection<KeyValuePair<string, string>>
+    , IReadOnlyDictionary<string, string>
+    , IDictionary<string, object?> // Allows using ProblemExtensionData directly in ProblemDetails.
+    , IEquatable<ProblemExtensionData>
+    , IEqualityOperators<ProblemExtensionData, ProblemExtensionData, bool>
+{
+    /// <summary>
+    /// Gets an empty <see cref="ProblemExtensionData"/>.
+    /// </summary>
+    public static ProblemExtensionData Empty
+        => new(ImmutableArray<KeyValuePair<string, string>>.Empty);
+
+    /// <summary>
+    /// Creates a new <see cref="ProblemExtensionData"/> with the specified <paramref name="values"/>.
+    /// </summary>
+    /// <param name="values">The extension data values.</param>
+    /// <returns>A new <see cref="ProblemExtensionData"/>.</returns>
+    public static ProblemExtensionData Create(ReadOnlySpan<KeyValuePair<string, string>> values)
+        => new(ImmutableArray.Create(values));
+
+    private readonly ImmutableArray<KeyValuePair<string, string>> _values;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProblemExtensionData"/> struct.
+    /// </summary>
+    /// <param name="values">The extension values.</param>
+    public ProblemExtensionData(ImmutableArray<KeyValuePair<string, string>> values)
+    {
+        _values = values;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether this struct was initialized without an actual array instance.
+    /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsDefault
+        => _values.IsDefault;
+
+    /// <summary>
+    /// Gets a value indicating whether this struct is empty or uninitialized.
+    /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public bool IsDefaultOrEmpty
+        => _values.IsDefaultOrEmpty;
+
+    /// <summary>
+    /// Gets the number of elements in the array.
+    /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public int Length
+        => _values.Length;
+
+    [ExcludeFromCodeCoverage]
+    private int DebuggerLength
+        => _values.IsDefault ? 0 : _values.Length;
+
+    /// <summary>
+    /// Creates a new read-only span over this immutable array.
+    /// </summary>
+    /// <returns>The read-only span representation of this immutable array.</returns>
+    public ReadOnlySpan<KeyValuePair<string, string>> AsSpan() => _values.AsSpan();
+
+    /// <summary>
+    /// Creates a new read-only memory region over this immutable array.
+    /// </summary>
+    /// <returns>The read-only memory representation of this immutable array.</returns>
+    public ReadOnlyMemory<KeyValuePair<string, string>> AsMemory() => _values.AsMemory();
+
+    /// <summary>
+    /// Implicitly converts a <see cref="ImmutableArray{T}"/> of <see cref="KeyValuePair{TKey, TValue}"/> to a <see cref="ProblemExtensionData"/>.
+    /// </summary>
+    /// <param name="values">The extension data.</param>
+    public static implicit operator ProblemExtensionData(ImmutableArray<KeyValuePair<string, string>> values)
+        => new(values);
+
+    /// <inheritdoc/>
+    public static bool operator ==(ProblemExtensionData left, ProblemExtensionData right)
+        => left.Equals(right);
+
+    /// <inheritdoc/>
+    public static bool operator !=(ProblemExtensionData left, ProblemExtensionData right)
+        => !left.Equals(right);
+
+    /// <inheritdoc/>
+    public ValuesEnumerable this[string key]
+        => new ValuesEnumerable(this, key);
+
+    /// <inheritdoc/>
+    public bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
+    {
+        foreach (var kvp in _values)
+        {
+            if (string.Equals(key, kvp.Key, StringComparison.Ordinal))
+            {
+                value = kvp.Value;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public bool ContainsKey(string key)
+        => TryGetValue(key, out _);
+
+    /// <inheritdoc/>
+    public override bool Equals([NotNullWhen(true)] object? obj)
+        => obj is ProblemExtensionData other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        if (_values.IsDefaultOrEmpty)
+        {
+            return 0;
+        }
+
+        var hash = new HashCode();
+        hash.Add(_values.Length);
+
+        // simple case, no sorting needed
+        if (_values.Length == 1)
+        {
+            var ext = _values[0];
+            hash.Add(string.GetHashCode(ext.Key, StringComparison.Ordinal));
+            hash.Add(string.GetHashCode(ext.Value, StringComparison.Ordinal));
+        }
+        else
+        {
+            var scratch = ArrayPool<(string Key, string Value, int Index)>.Shared.Rent(_values.Length);
+            try
+            {
+                for (var i = 0; i < _values.Length; i++)
+                {
+                    var (key, value) = _values[i];
+                    scratch[i] = (key, value, i);
+                }
+
+                var span = scratch.AsSpan(0, _values.Length);
+                span.Sort((a, b) => string.Compare(a.Key, b.Key, StringComparison.Ordinal) switch
+                    {
+                        0 => string.Compare(a.Value, b.Value, StringComparison.Ordinal),
+                        var result => result,
+                    });
+
+                foreach (var (key, value, index) in span)
+                {
+                    hash.Add(string.GetHashCode(key, StringComparison.Ordinal));
+                    hash.Add(string.GetHashCode(value, StringComparison.Ordinal));
+                }
+            }
+            finally
+            {
+                ArrayPool<(string Key, string Value, int Index)>.Shared.Return(scratch);
+            }
+        }
+
+        return hash.ToHashCode();
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(ProblemExtensionData other)
+    {
+        if (!_values.IsDefaultOrEmpty)
+        {
+            if (other._values.IsDefaultOrEmpty)
+            {
+                return false;
+            }
+
+            if (_values.Length != other._values.Length)
+            {
+                return false;
+            }
+
+            // simple case
+            if (_values.Length == 1)
+            {
+                if (!string.Equals(other._values[0].Key, _values[0].Key, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                if (!string.Equals(other._values[0].Value, _values[0].Value, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+            else if (_values.Length <= 16)
+            {
+                Span<int> seen = stackalloc int[16];
+                return CheckWithSeen(seen[.._values.Length], _values.AsSpan(), other._values.AsSpan());
+            }
+            else
+            {
+                var rented = ArrayPool<int>.Shared.Rent(_values.Length);
+                try
+                {
+                    Span<int> seen = rented.AsSpan(0, _values.Length);
+                    return CheckWithSeen(seen, _values.AsSpan(), other._values.AsSpan());
+                }
+                finally
+                {
+                    ArrayPool<int>.Shared.Return(rented);
+                }
+            }
+        }
+        else
+        {
+            return other._values.IsDefaultOrEmpty;
+        }
+
+        return true;
+
+        static bool CheckWithSeen(Span<int> seen, ReadOnlySpan<KeyValuePair<string, string>> left, ReadOnlySpan<KeyValuePair<string, string>> right)
+        {
+            Debug.Assert(left.Length == right.Length);
+            Debug.Assert(left.Length == seen.Length);
+
+            var index = 0;
+            foreach (var (key, value) in left)
+            {
+                if (!TryFind(right, key, value, seen[..index], out var foundIndex))
+                {
+                    return false;
+                }
+
+                seen[index++] = foundIndex;
+            }
+
+            return true;
+        }
+
+        static bool TryFind(ReadOnlySpan<KeyValuePair<string, string>> right, string key, string value, ReadOnlySpan<int> ignore, out int index)
+        {
+            for (var i = 0; i < right.Length; i++)
+            {
+                if (ignore.Contains(i))
+                {
+                    continue;
+                }
+
+                var (rightKey, rightValue) = right[i];
+                if (string.Equals(key, rightKey, StringComparison.Ordinal)
+                    && string.Equals(value, rightValue, StringComparison.Ordinal))
+                {
+                    index = i;
+                    return true;
+                }
+            }
+
+            index = default;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Returns an enumerator for the contents of the array.
+    /// </summary>
+    /// <returns>An enumerator.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ImmutableArray<KeyValuePair<string, string>>.Enumerator GetEnumerator() => _values.GetEnumerator();
+
+    bool ICollection<KeyValuePair<string, object?>>.IsReadOnly => true;
+
+    int ICollection<KeyValuePair<string, object?>>.Count => _values.Length;
+
+    int IReadOnlyCollection<KeyValuePair<string, string>>.Count => _values.Length;
+
+    IEnumerator IEnumerable.GetEnumerator() => (_values as IEnumerable).GetEnumerator();
+
+    IEnumerator<KeyValuePair<string, string>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator()
+        => (_values as IEnumerable<KeyValuePair<string, string>>).GetEnumerator();
+
+    IEnumerator<KeyValuePair<string, object?>> IEnumerable<KeyValuePair<string, object?>>.GetEnumerator()
+        => _values.Select(static kvp => new KeyValuePair<string, object?>(kvp.Key, kvp.Value)).GetEnumerator();
+
+    IEnumerable<string> IReadOnlyDictionary<string, string>.Keys => new KeysCollection(this);
+
+    ICollection<string> IDictionary<string, object?>.Keys => new KeysCollection(this);
+
+    IEnumerable<string> IReadOnlyDictionary<string, string>.Values => new ValuesCollection(this);
+
+    ICollection<object?> IDictionary<string, object?>.Values => new ValuesCollection(this);
+
+    object? IDictionary<string, object?>.this[string key]
+    {
+        get => this[key];
+        set => ThrowHelper.ThrowNotSupportedException();
+    }
+
+    string IReadOnlyDictionary<string, string>.this[string key]
+        => TryGetValue(key, out var value)
+        ? value
+        : ThrowHelper.ThrowArgumentOutOfRangeException<string>(nameof(key));
+
+    void IDictionary<string, object?>.Add(string key, object? value) => ThrowHelper.ThrowNotSupportedException();
+
+    bool IDictionary<string, object?>.Remove(string key) => ThrowHelper.ThrowNotSupportedException<bool>();
+
+    bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item) => ThrowHelper.ThrowNotSupportedException<bool>();
+
+    void ICollection<KeyValuePair<string, object?>>.Add(KeyValuePair<string, object?> item) => ThrowHelper.ThrowNotSupportedException();
+
+    void ICollection<KeyValuePair<string, object?>>.Clear() => ThrowHelper.ThrowNotSupportedException();
+
+    bool ICollection<KeyValuePair<string, object?>>.Contains(KeyValuePair<string, object?> item)
+        => item.Value is string itemValue
+        && TryGetValue(item.Key, out var value)
+        && string.Equals(itemValue, value, StringComparison.Ordinal);
+
+    bool IDictionary<string, object?>.ContainsKey(string key) => ContainsKey(key);
+
+    bool IDictionary<string, object?>.TryGetValue(string key, out object? value)
+    {
+        if (TryGetValue(key, out var stringValue))
+        {
+            value = stringValue;
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    void ICollection<KeyValuePair<string, object?>>.CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex)
+    {
+        Guard.HasSizeGreaterThanOrEqualTo(array, arrayIndex + _values.Length);
+
+        foreach (var kvp in _values)
+        {
+            array[arrayIndex++] = new KeyValuePair<string, object?>(kvp.Key, kvp.Value);
+        }
+    }
+
+    private class ValuesCollection
+        : ICollection<object?> // IDictionary<string, object?>.Values
+        , IEnumerable<string> // IReadOnlyDictionary<string, string>.Values
+    {
+        private readonly ProblemExtensionData _values;
+
+        public ValuesCollection(ProblemExtensionData values)
+        {
+            _values = values;
+        }
+
+        int ICollection<object?>.Count => _values.Length;
+
+        bool ICollection<object?>.IsReadOnly => true;
+
+        void ICollection<object?>.Add(object? item) => ThrowHelper.ThrowNotSupportedException();
+
+        void ICollection<object?>.Clear() => ThrowHelper.ThrowNotSupportedException();
+
+        bool ICollection<object?>.Contains(object? item)
+            => item is string stringItem
+            && _values._values.Any(kvp => string.Equals(kvp.Value, stringItem, StringComparison.Ordinal));
+
+        void ICollection<object?>.CopyTo(object?[] array, int arrayIndex)
+        {
+            Guard.HasSizeGreaterThanOrEqualTo(array, arrayIndex + _values.Length);
+
+            foreach (var kvp in _values._values)
+            {
+                array[arrayIndex++] = kvp.Value;
+            }
+        }
+
+        IEnumerator<object?> IEnumerable<object?>.GetEnumerator()
+            => _values._values.Select(static kvp => (object?)kvp.Value).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => _values._values.Select(static kvp => kvp.Value).GetEnumerator();
+
+        IEnumerator<string> IEnumerable<string>.GetEnumerator()
+            => _values._values.Select(static kvp => kvp.Value).GetEnumerator();
+
+        bool ICollection<object?>.Remove(object? item) => ThrowHelper.ThrowNotSupportedException<bool>();
+    }
+
+    private class KeysCollection
+        : ICollection<string> // IDictionary<string, object?>.Keys
+        , IEnumerable<string> // IReadOnlyDictionary<string, string>.Keys
+    {
+        private readonly ProblemExtensionData _values;
+
+        public KeysCollection(ProblemExtensionData values)
+        {
+            _values = values;
+        }
+
+        int ICollection<string>.Count => _values.Length;
+
+        bool ICollection<string>.IsReadOnly => true;
+
+        void ICollection<string>.Add(string item) => ThrowHelper.ThrowNotSupportedException();
+
+        void ICollection<string>.Clear() => ThrowHelper.ThrowNotSupportedException();
+
+        bool ICollection<string>.Contains(string item)
+            => _values._values.Any(kvp => string.Equals(kvp.Key, item, StringComparison.Ordinal));
+
+        void ICollection<string>.CopyTo(string[] array, int arrayIndex)
+        {
+            Guard.HasSizeGreaterThanOrEqualTo(array, arrayIndex + _values.Length);
+
+            foreach (var kvp in _values._values)
+            {
+                array[arrayIndex++] = kvp.Key;
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => _values._values.Select(static kvp => kvp.Key).GetEnumerator();
+
+        IEnumerator<string> IEnumerable<string>.GetEnumerator()
+            => _values._values.Select(static kvp => kvp.Key).GetEnumerator();
+
+        bool ICollection<string>.Remove(string item) => ThrowHelper.ThrowNotSupportedException<bool>();
+    }
+
+    /// <summary>
+    /// An enumerable of values for a specific key in a <see cref="ProblemExtensionData"/>.
+    /// </summary>
+    public readonly struct ValuesEnumerable
+        : IEnumerable<string>
+    {
+        private readonly ProblemExtensionData _data;
+        private readonly string _key;
+
+        internal ValuesEnumerable(ProblemExtensionData data, string key)
+        {
+            _data = data;
+            _key = key;
+        }
+
+        /// <inheritdoc/>
+        public ValuesEnumerator GetEnumerator() 
+            => new(_key, _data._values.GetEnumerator());
+
+        IEnumerator<string> IEnumerable<string>.GetEnumerator()
+            => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+    }
+
+    /// <summary>
+    /// An enumerator for the values of a specific key in a <see cref="ProblemExtensionData"/>.
+    /// </summary>
+    public struct ValuesEnumerator
+        : IEnumerator<string>
+    {
+        private readonly string _key;
+        private ImmutableArray<KeyValuePair<string, string>>.Enumerator _enumerator;
+
+        internal ValuesEnumerator(string key, ImmutableArray<KeyValuePair<string, string>>.Enumerator enumerator)
+        {
+            _key = key;
+            _enumerator = enumerator;
+        }
+
+        /// <inheritdoc/>
+        public string Current 
+            => _enumerator.Current.Value;
+
+        object IEnumerator.Current 
+            => Current;
+
+        /// <inheritdoc/>
+        public bool MoveNext()
+        {
+            while (_enumerator.MoveNext())
+            {
+                if (string.Equals(_enumerator.Current.Key, _key, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        void IEnumerator.Reset()
+        {
+        }
+
+        void IDisposable.Dispose()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Displays <see cref="ProblemExtensionData"/> in the debugger.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    private sealed class ProblemExtensionDataDebuggerProxy
+    {
+        /// <summary>
+        /// The <see cref="ProblemExtensionData"/> being debugged.
+        /// </summary>
+        private readonly ProblemExtensionData _data;
+
+        /// <summary>
+        /// The contents of the <see cref="ProblemExtensionData"/>, cached into an array.
+        /// </summary>
+        private ProblemExtensionItemDebuggerView[]? _cachedContents;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProblemExtensionDataDebuggerProxy"/> class.
+        /// </summary>
+        /// <param name="data">The <see cref="ProblemExtensionData"/> to show in the debugger.</param>
+        public ProblemExtensionDataDebuggerProxy(ProblemExtensionData data)
+        {
+            _data = data;
+
+            if (_data.IsDefaultOrEmpty)
+            {
+                _cachedContents = Array.Empty<ProblemExtensionItemDebuggerView>();
+            }
+        }
+
+        /// <summary>
+        /// Gets the contents of the dictionary for the display in the debugger.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public ProblemExtensionItemDebuggerView[] Contents
+            => _cachedContents
+            ??= _data._values.Select(ProblemExtensionItemDebuggerView.From).ToArray();
+    }
+
+    /// <summary>
+    /// Defines a key/value pair for displaying an item of a dictionary by a debugger.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    [DebuggerDisplay("{Value}", Name = "[{Key}]")]
+    private readonly struct ProblemExtensionItemDebuggerView
+    {
+        public static ProblemExtensionItemDebuggerView From(KeyValuePair<string, string> value)
+        {
+            return new(value);
+        }
+
+        public ProblemExtensionItemDebuggerView(KeyValuePair<string, string> value)
+        {
+            Key = value.Key;
+            Value = value.Value;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+        public string Key { get; }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+        public string Value { get; }
+    }
+}

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ProblemExtensionData.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ProblemExtensionData.cs
@@ -125,10 +125,6 @@ public readonly struct ProblemExtensionData
         => TryGetValue(key, out _);
 
     /// <inheritdoc/>
-    public override bool Equals([NotNullWhen(true)] object? obj)
-        => obj is ProblemExtensionData other && Equals(other);
-
-    /// <inheritdoc/>
     public override int GetHashCode()
     {
         if (_values.IsDefaultOrEmpty)
@@ -178,6 +174,10 @@ public readonly struct ProblemExtensionData
 
         return hash.ToHashCode();
     }
+
+    /// <inheritdoc/>
+    public override bool Equals([NotNullWhen(true)] object? obj)
+        => obj is ProblemExtensionData other && Equals(other);
 
     /// <inheritdoc/>
     public bool Equals(ProblemExtensionData other)
@@ -354,7 +354,7 @@ public readonly struct ProblemExtensionData
         }
     }
 
-    private class ValuesCollection
+    private sealed class ValuesCollection
         : ICollection<object?> // IDictionary<string, object?>.Values
         , IEnumerable<string> // IReadOnlyDictionary<string, string>.Values
     {
@@ -399,7 +399,7 @@ public readonly struct ProblemExtensionData
         bool ICollection<object?>.Remove(object? item) => ThrowHelper.ThrowNotSupportedException<bool>();
     }
 
-    private class KeysCollection
+    private sealed class KeysCollection
         : ICollection<string> // IDictionary<string, object?>.Keys
         , IEnumerable<string> // IReadOnlyDictionary<string, string>.Keys
     {

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ProblemExtensions.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ProblemExtensions.cs
@@ -13,8 +13,8 @@ public static class ProblemExtensions
     public static ProblemInstance Create(this ProblemDescriptor descriptor) 
         => ProblemInstance.Create(descriptor);
 
-    /// <inheritdoc cref="ProblemInstance.Create(ProblemDescriptor, ImmutableArray{KeyValuePair{string, string}})"/>
-    public static ProblemInstance Create(this ProblemDescriptor descriptor, ImmutableArray<KeyValuePair<string, string>> extensions) 
+    /// <inheritdoc cref="ProblemInstance.Create(ProblemDescriptor, ProblemExtensionData)"/>
+    public static ProblemInstance Create(this ProblemDescriptor descriptor, ProblemExtensionData extensions) 
         => ProblemInstance.Create(descriptor, extensions);
 
     /// <inheritdoc cref="ProblemInstance.Create(ProblemDescriptor, IReadOnlyDictionary{string, string})"/>
@@ -39,32 +39,32 @@ public static class ProblemExtensions
     public static ValidationErrorInstance Create(this ValidationErrorDescriptor descriptor, IEnumerable<string> paths)
         => ValidationErrorInstance.Create(descriptor, paths);
 
-    /// <inheritdoc cref="ValidationErrorInstance.Create(ValidationErrorDescriptor, ImmutableArray{KeyValuePair{string, string}})"/>
-    public static ValidationErrorInstance Create(this ValidationErrorDescriptor descriptor, ImmutableArray<KeyValuePair<string, string>> extensions)
+    /// <inheritdoc cref="ValidationErrorInstance.Create(ValidationErrorDescriptor, ProblemExtensionData)"/>
+    public static ValidationErrorInstance Create(this ValidationErrorDescriptor descriptor, ProblemExtensionData extensions)
         => ValidationErrorInstance.Create(descriptor, extensions);
 
     /// <inheritdoc cref="ValidationErrorInstance.Create(ValidationErrorDescriptor, IReadOnlyDictionary{string, string})"/>
     public static ValidationErrorInstance Create(this ValidationErrorDescriptor descriptor, IReadOnlyDictionary<string, string> extensions)
         => ValidationErrorInstance.Create(descriptor, extensions);
 
-    /// <inheritdoc cref="ValidationErrorInstance.Create(ValidationErrorDescriptor, string, ImmutableArray{KeyValuePair{string, string}})"/>
-    public static ValidationErrorInstance Create(this ValidationErrorDescriptor descriptor, string path, ImmutableArray<KeyValuePair<string, string>> extensions)
+    /// <inheritdoc cref="ValidationErrorInstance.Create(ValidationErrorDescriptor, string, ProblemExtensionData)"/>
+    public static ValidationErrorInstance Create(this ValidationErrorDescriptor descriptor, string path, ProblemExtensionData extensions)
         => ValidationErrorInstance.Create(descriptor, path, extensions);
 
     /// <inheritdoc cref="ValidationErrorInstance.Create(ValidationErrorDescriptor, string, IReadOnlyDictionary{string, string})"/>
     public static ValidationErrorInstance Create(this ValidationErrorDescriptor descriptor, string path, IReadOnlyDictionary<string, string> extensions)
         => ValidationErrorInstance.Create(descriptor, path, extensions);
 
-    /// <inheritdoc cref="ValidationErrorInstance.Create(ValidationErrorDescriptor, ImmutableArray{string}, ImmutableArray{KeyValuePair{string, string}})"/>
-    public static ValidationErrorInstance Create(this ValidationErrorDescriptor descriptor, ImmutableArray<string> paths, ImmutableArray<KeyValuePair<string, string>> extensions)
+    /// <inheritdoc cref="ValidationErrorInstance.Create(ValidationErrorDescriptor, ImmutableArray{string}, ProblemExtensionData)"/>
+    public static ValidationErrorInstance Create(this ValidationErrorDescriptor descriptor, ImmutableArray<string> paths, ProblemExtensionData extensions)
         => ValidationErrorInstance.Create(descriptor, paths, extensions);
 
     /// <inheritdoc cref="ValidationErrorInstance.Create(ValidationErrorDescriptor, ImmutableArray{string}, IReadOnlyDictionary{string, string})"/>
     public static ValidationErrorInstance Create(this ValidationErrorDescriptor descriptor, ImmutableArray<string> paths, IReadOnlyDictionary<string, string> extensions)
         => ValidationErrorInstance.Create(descriptor, paths, extensions);
 
-    /// <inheritdoc cref="ValidationErrorInstance.Create(ValidationErrorDescriptor, IEnumerable{string}, ImmutableArray{KeyValuePair{string, string}})"/>
-    public static ValidationErrorInstance Create(this ValidationErrorDescriptor descriptor, IEnumerable<string> paths, ImmutableArray<KeyValuePair<string, string>> extensions)
+    /// <inheritdoc cref="ValidationErrorInstance.Create(ValidationErrorDescriptor, IEnumerable{string}, ProblemExtensionData)"/>
+    public static ValidationErrorInstance Create(this ValidationErrorDescriptor descriptor, IEnumerable<string> paths, ProblemExtensionData extensions)
         => ValidationErrorInstance.Create(descriptor, paths, extensions);
 
     /// <inheritdoc cref="ValidationErrorInstance.Create(ValidationErrorDescriptor, IEnumerable{string}, IReadOnlyDictionary{string, string})"/>

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ProblemInstance.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ProblemInstance.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Net;
 
 namespace Altinn.Authorization.ProblemDetails;
@@ -8,7 +7,7 @@ namespace Altinn.Authorization.ProblemDetails;
 /// An instance of a <see cref="ProblemDescriptor"/>, with optional extensions.
 /// </summary>
 [DebuggerDisplay("{ErrorCode,nq}: {Detail,nq}")]
-public sealed class ProblemInstance
+public record class ProblemInstance
 {
     /// <summary>
     /// Creates a new <see cref="ProblemInstance"/> with the specified <paramref name="descriptor"/>.
@@ -24,7 +23,7 @@ public sealed class ProblemInstance
     /// <param name="descriptor">The <see cref="ProblemDescriptor"/>.</param>
     /// <param name="extensions">The extensions.</param>
     /// <returns>A <see cref="ProblemInstance"/>.</returns>
-    public static ProblemInstance Create(ProblemDescriptor descriptor, ImmutableArray<KeyValuePair<string, string>> extensions) 
+    public static ProblemInstance Create(ProblemDescriptor descriptor, ProblemExtensionData extensions) 
         => new ProblemInstance(descriptor, extensions);
 
     /// <summary>
@@ -37,14 +36,14 @@ public sealed class ProblemInstance
         => new ProblemInstance(descriptor, [..extensions]);
 
     private readonly ProblemDescriptor _descriptor;
-    private readonly ImmutableArray<KeyValuePair<string, string>> _extensions;
+    private readonly ProblemExtensionData _extensions;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProblemInstance"/> class.
     /// </summary>
     /// <param name="descriptor">The problem descriptor.</param>
     /// <param name="extensions">The extensions.</param>
-    internal ProblemInstance(ProblemDescriptor descriptor, ImmutableArray<KeyValuePair<string, string>> extensions)
+    internal ProblemInstance(ProblemDescriptor descriptor, ProblemExtensionData extensions)
     {
         _descriptor = descriptor;
         _extensions = extensions;
@@ -62,7 +61,11 @@ public sealed class ProblemInstance
     /// <summary>
     /// Gets the extensions.
     /// </summary>
-    public ImmutableArray<KeyValuePair<string, string>> Extensions => _extensions;
+    public ProblemExtensionData Extensions
+    {
+        get => _extensions;
+        internal init => _extensions = value;
+    }
 
     /// <summary>
     /// Implicitly converts a <see cref="ProblemDescriptor"/> to a <see cref="ProblemInstance"/>.

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/Result.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/Result.cs
@@ -1,0 +1,149 @@
+﻿using CommunityToolkit.Diagnostics;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace Altinn.Authorization.ProblemDetails;
+
+/// <summary>
+/// A (potentially failed) result of an operation.
+/// </summary>
+/// <typeparam name="T">The result type.</typeparam>
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public readonly struct Result<T>
+    : IEquatable<Result<T>>
+    , IEqualityOperators<Result<T>, Result<T>, bool>
+    where T : notnull
+{
+    /// <summary>
+    /// <see langword="null"/> if <see cref="_result"/> has the result, otherwise a <see cref="ProblemInstance"/>.
+    /// </summary>
+    private readonly ProblemInstance? _problem;
+
+    /// <summary>
+    /// The result to be used if the operation completed successfully.
+    /// </summary>
+    private readonly T? _result;
+
+    /// <summary>
+    /// Gets a value indicating whether the operation failed.
+    /// </summary>
+    [MemberNotNullWhen(false, nameof(Value))]
+    [MemberNotNullWhen(true, nameof(Problem))]
+    public bool IsProblem
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _problem is not null;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the operation succeeded.
+    /// </summary>
+    [MemberNotNullWhen(true, nameof(Value))]
+    [MemberNotNullWhen(false, nameof(Problem))]
+    public bool IsSuccess
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _problem is null;
+    }
+
+    /// <summary>
+    /// Gets the problem instance if the operation failed, otherwise <see langword="null"/>.
+    /// </summary>
+    public ProblemInstance? Problem
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _problem;
+    }
+
+    /// <summary>
+    /// Gets the result if the operation succeeded, otherwise <see langword="default"/>(<typeparamref name="T"/>).
+    /// </summary>
+    public T? Value
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _result;
+    }
+
+    // An instance created with the default ctor (a zero init'd struct) represents a successfully completed operation
+    // with a result of default(T).
+
+    /// <summary>
+    /// Initializes the <see cref="Result{T}"/> with a <typeparamref name="T"/> result value.
+    /// </summary>
+    /// <param name="result">The result.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Result(T result)
+    {
+        _result = result;
+        _problem = null;
+    }
+
+    /// <summary>
+    /// Initializes the <see cref="Result{T}"/> with a <see cref="ProblemInstance"/>.
+    /// </summary>
+    /// <param name="problemInstance">The <see cref="ProblemInstance"/>.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Result(ProblemInstance problemInstance)
+    {
+        Guard.IsNotNull(problemInstance);
+
+        _result = default;
+        _problem = problemInstance;
+    }
+
+    /// <summary>
+    /// Implicitly converts a <typeparamref name="T"/> to a <see cref="Result{T}"/>.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Result<T>(T value)
+        => new(value);
+
+    /// <summary>
+    /// Implicitly converts a <see cref="ProblemInstance"/> to a <see cref="Result{T}"/>.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Result<T>(ProblemInstance value)
+        => new(value);
+
+    /// <summary>
+    /// Implicitly converts a <see cref="ProblemDescriptor"/> to a <see cref="Result{T}"/>.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Result<T>(ProblemDescriptor value)
+        => new(value);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+        => _problem is not null ? _problem.GetHashCode()
+        : _result is not null ? _result.GetHashCode()
+        : 0;
+
+    /// <inheritdoc/>
+    public override bool Equals([NotNullWhen(true)] object? obj)
+        => obj is Result<T> other && Equals(other);
+
+    /// <inheritdoc/>
+    public bool Equals(Result<T> other)
+        => _problem is not null || other._problem is not null
+        ? _problem == other._problem
+        : EqualityComparer<T>.Default.Equals(_result, other._result);
+
+    /// <inheritdoc/>
+    public static bool operator ==(Result<T> left, Result<T> right)
+        => left.Equals(right);
+
+    /// <inheritdoc/>
+    public static bool operator !=(Result<T> left, Result<T> right)
+        => !left.Equals(right);
+
+    private string DebuggerDisplay
+        => _problem is not null
+        ? $"Problem: {_problem.ErrorCode}"
+        : string.Create(CultureInfo.InvariantCulture, $"Value: {_result}");
+}

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/StdValidationErrors.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/StdValidationErrors.cs
@@ -13,4 +13,16 @@ public static class StdValidationErrors
     /// </summary>
     public static ValidationErrorDescriptor Required { get; }
         = _factory.Create(0, "The field is required.");
+
+    /// <summary>
+    /// Standard problem descriptors' error codes.
+    /// </summary>
+    public static class ErrorCodes
+    {
+        /// <summary>
+        /// Gets the error code for a required validation-error.
+        /// </summary>
+        public static ErrorCode Required
+            => StdValidationErrors.Required.ErrorCode;
+    }
 }

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ValidationErrorBuilder.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ValidationErrorBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.Authorization.ProblemDetails;
 
@@ -63,25 +64,24 @@ public struct ValidationErrorBuilder
         };
 
     /// <summary>
-    /// Converts the validation errors to an immutable array of <typeparamref name="T"/>s.
+    /// Creates a new <see cref="ValidationProblemInstance"/> from this builder if any
+    /// validation errors have been added.
     /// </summary>
-    /// <typeparam name="T">The type to map errors to.</typeparam>
-    /// <param name="mapper">The mapper.</param>
-    /// <returns>A <see cref="ImmutableArray{T}"/> of <typeparamref name="T"/>s.</returns>
-    public readonly ImmutableArray<T> MapToImmutable<T>(Func<ValidationErrorInstance, T> mapper)
+    /// <param name="instance">The resulting <see cref="ValidationProblemInstance"/>.</param>
+    /// <returns>
+    /// <see langword="true"/> if any validation errors have been added and the <paramref name="instance"/>
+    /// has been created; otherwise <see langword="false"/>.
+    /// </returns>
+    public readonly bool TryBuild([NotNullWhen(true)] out ValidationProblemInstance? instance)
     {
         var errors = _errors;
-        if (errors is null)
+        if (errors is null or { Count: 0 })
         {
-            return [];
+            instance = null;
+            return false;
         }
 
-        var builder = ImmutableArray.CreateBuilder<T>(errors.Count);
-        foreach (var error in errors)
-        {
-            builder.Add(mapper(error));
-        }
-
-        return builder.MoveToImmutable();
+        instance = new(errors: [.. errors], extensions: []);
+        return true;
     }
 }

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ValidationErrorBuilderExtensions.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ValidationErrorBuilderExtensions.cs
@@ -1,0 +1,123 @@
+﻿using System.Collections.Immutable;
+
+namespace Altinn.Authorization.ProblemDetails;
+
+/// <summary>
+/// Extensions for <see cref="ValidationErrorBuilder"/>.
+/// </summary>
+public static class ValidationErrorBuilderExtensions
+{
+    /// <summary>
+    /// Adds a validation error with the specified <paramref name="descriptor"/>.
+    /// </summary>
+    /// <param name="errors">The error collection.</param>
+    /// <param name="descriptor">The <see cref="ValidationErrorDescriptor"/>.</param>
+    /// <returns>A <see cref="ValidationErrorInstance"/>.</returns>
+    public static void Add(this ref ValidationErrorBuilder errors, ValidationErrorDescriptor descriptor)
+        => errors.Add(descriptor.Create());
+
+    /// <summary>
+    /// Adds a validation error with the specified <paramref name="descriptor"/> and <paramref name="path"/>.
+    /// </summary>
+    /// <param name="errors">The error collection.</param>
+    /// <param name="descriptor">The <see cref="ValidationErrorDescriptor"/>.</param>
+    /// <param name="path">The path.</param>
+    public static void Add(this ref ValidationErrorBuilder errors, ValidationErrorDescriptor descriptor, string path)
+        => errors.Add(descriptor.Create(path));
+
+    /// <summary>
+    /// Adds a validation error with the specified <paramref name="descriptor"/> and <paramref name="paths"/>.
+    /// </summary>
+    /// <param name="errors">The error collection.</param>
+    /// <param name="descriptor">The <see cref="ValidationErrorDescriptor"/>.</param>
+    /// <param name="paths">The paths.</param>
+    public static void Add(this ref ValidationErrorBuilder errors, ValidationErrorDescriptor descriptor, ImmutableArray<string> paths)
+        => errors.Add(descriptor.Create(paths));
+
+    /// <summary>
+    /// Adds a validation error with the specified <paramref name="descriptor"/> and <paramref name="paths"/>.
+    /// </summary>
+    /// <param name="errors">The error collection.</param>
+    /// <param name="descriptor">The <see cref="ValidationErrorDescriptor"/>.</param>
+    /// <param name="paths">The paths.</param>
+    public static void Add(this ref ValidationErrorBuilder errors, ValidationErrorDescriptor descriptor, IEnumerable<string> paths)
+        => errors.Add(descriptor.Create(paths));
+
+    /// <summary>
+    /// Adds a validation error with the specified <paramref name="descriptor"/> and <paramref name="extensions"/>.
+    /// </summary>
+    /// <param name="errors">The error collection.</param>
+    /// <param name="descriptor">The <see cref="ValidationErrorDescriptor"/>.</param>
+    /// <param name="extensions">The extensions.</param>
+    public static void Add(this ref ValidationErrorBuilder errors, ValidationErrorDescriptor descriptor, ProblemExtensionData extensions)
+        => errors.Add(descriptor.Create(extensions));
+
+    /// <summary>
+    /// Adds a validation error with the specified <paramref name="descriptor"/> and <paramref name="extensions"/>.
+    /// </summary>
+    /// <param name="errors">The error collection.</param>
+    /// <param name="descriptor">The <see cref="ValidationErrorDescriptor"/>.</param>
+    /// <param name="extensions">The extensions.</param>
+    public static void Add(this ref ValidationErrorBuilder errors, ValidationErrorDescriptor descriptor, IReadOnlyDictionary<string, string> extensions)
+        => errors.Add(descriptor.Create(extensions));
+
+    /// <summary>
+    /// Adds a validation error with the specified <paramref name="descriptor"/>, <paramref name="path"/>, and <paramref name="extensions"/>.
+    /// </summary>
+    /// <param name="errors">The error collection.</param>
+    /// <param name="descriptor">The <see cref="ValidationErrorDescriptor"/>.</param>
+    /// <param name="path">The path.</param>
+    /// <param name="extensions">The extensions.</param>
+    public static void Add(this ref ValidationErrorBuilder errors, ValidationErrorDescriptor descriptor, string path, ProblemExtensionData extensions)
+        => errors.Add(descriptor.Create(path, extensions));
+
+    /// <summary>
+    /// Adds a validation error with the specified <paramref name="descriptor"/>, <paramref name="path"/>, and <paramref name="extensions"/>.
+    /// </summary>
+    /// <param name="errors">The error collection.</param>
+    /// <param name="descriptor">The <see cref="ValidationErrorDescriptor"/>.</param>
+    /// <param name="path">The path.</param>
+    /// <param name="extensions">The extensions.</param>
+    public static void Add(this ref ValidationErrorBuilder errors, ValidationErrorDescriptor descriptor, string path, IReadOnlyDictionary<string, string> extensions)
+        => errors.Add(descriptor.Create(path, extensions));
+
+    /// <summary>
+    /// Adds a validation error with the specified <paramref name="descriptor"/>, <paramref name="paths"/>, and <paramref name="extensions"/>.
+    /// </summary>
+    /// <param name="errors">The error collection.</param>
+    /// <param name="descriptor">The <see cref="ValidationErrorDescriptor"/>.</param>
+    /// <param name="paths">The paths.</param>
+    /// <param name="extensions">The extensions.</param>
+    public static void Add(this ref ValidationErrorBuilder errors, ValidationErrorDescriptor descriptor, ImmutableArray<string> paths, ProblemExtensionData extensions)
+        => errors.Add(descriptor.Create(paths, extensions));
+
+    /// <summary>
+    /// Adds a validation error with the specified <paramref name="descriptor"/>, <paramref name="paths"/>, and <paramref name="extensions"/>.
+    /// </summary>
+    /// <param name="errors">The error collection.</param>
+    /// <param name="descriptor">The <see cref="ValidationErrorDescriptor"/>.</param>
+    /// <param name="paths">The paths.</param>
+    /// <param name="extensions">The extensions.</param>
+    public static void Add(this ref ValidationErrorBuilder errors, ValidationErrorDescriptor descriptor, ImmutableArray<string> paths, IReadOnlyDictionary<string, string> extensions)
+        => errors.Add(descriptor.Create(paths, extensions));
+
+    /// <summary>
+    /// Adds a validation error with the specified <paramref name="descriptor"/>, <paramref name="paths"/>, and <paramref name="extensions"/>.
+    /// </summary>
+    /// <param name="errors">The error collection.</param>
+    /// <param name="descriptor">The <see cref="ValidationErrorDescriptor"/>.</param>
+    /// <param name="paths">The paths.</param>
+    /// <param name="extensions">The extensions.</param>
+    public static void Add(this ref ValidationErrorBuilder errors, ValidationErrorDescriptor descriptor, IEnumerable<string> paths, ProblemExtensionData extensions)
+        => errors.Add(descriptor.Create(paths, extensions));
+
+    /// <summary>
+    /// Adds a validation error with the specified <paramref name="descriptor"/>, <paramref name="paths"/>, and <paramref name="extensions"/>.
+    /// </summary>
+    /// <param name="errors">The error collection.</param>
+    /// <param name="descriptor">The <see cref="ValidationErrorDescriptor"/>.</param>
+    /// <param name="paths">The paths.</param>
+    /// <param name="extensions">The extensions.</param>
+    public static void Add(this ref ValidationErrorBuilder errors, ValidationErrorDescriptor descriptor, IEnumerable<string> paths, IReadOnlyDictionary<string, string> extensions)
+        => errors.Add(descriptor.Create(paths, extensions));
+}

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ValidationErrorDescriptor.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ValidationErrorDescriptor.cs
@@ -1,11 +1,13 @@
 ﻿using CommunityToolkit.Diagnostics;
+using System.Diagnostics;
 
 namespace Altinn.Authorization.ProblemDetails;
 
 /// <summary>
 /// An immutable descriptor for a validation error.
 /// </summary>
-public sealed class ValidationErrorDescriptor
+[DebuggerDisplay("{ErrorCode,nq}: {Detail,nq}")]
+public sealed record class ValidationErrorDescriptor
 {
     /// <summary>
     /// Gets the error code.

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ValidationErrorInstance.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ValidationErrorInstance.cs
@@ -1,11 +1,13 @@
 ﻿using System.Collections.Immutable;
+using System.Diagnostics;
 
 namespace Altinn.Authorization.ProblemDetails;
 
 /// <summary>
 /// An instance of a <see cref="ValidationErrorDescriptor"/>, with optional paths and extensions.
 /// </summary>
-public sealed class ValidationErrorInstance
+[DebuggerDisplay("{ErrorCode,nq}: {Detail,nq}")]
+public sealed record class ValidationErrorInstance
 {
     /// <summary>
     /// Creates a new <see cref="ValidationErrorInstance"/> with the specified <paramref name="descriptor"/>.
@@ -48,7 +50,7 @@ public sealed class ValidationErrorInstance
     /// <param name="descriptor">The <see cref="ValidationErrorDescriptor"/>.</param>
     /// <param name="extensions">The extensions.</param>
     /// <returns>A <see cref="ValidationErrorInstance"/>.</returns>
-    public static ValidationErrorInstance Create(ValidationErrorDescriptor descriptor, ImmutableArray<KeyValuePair<string, string>> extensions) 
+    public static ValidationErrorInstance Create(ValidationErrorDescriptor descriptor, ProblemExtensionData extensions) 
         => new ValidationErrorInstance(descriptor, paths: [], extensions: extensions);
 
     /// <summary>
@@ -67,7 +69,7 @@ public sealed class ValidationErrorInstance
     /// <param name="path">The path.</param>
     /// <param name="extensions">The extensions.</param>
     /// <returns>A <see cref="ValidationErrorInstance"/>.</returns>
-    public static ValidationErrorInstance Create(ValidationErrorDescriptor descriptor, string path, ImmutableArray<KeyValuePair<string, string>> extensions) 
+    public static ValidationErrorInstance Create(ValidationErrorDescriptor descriptor, string path, ProblemExtensionData extensions) 
         => new ValidationErrorInstance(descriptor, paths: [path], extensions: extensions);
 
     /// <summary>
@@ -87,7 +89,7 @@ public sealed class ValidationErrorInstance
     /// <param name="paths">The paths.</param>
     /// <param name="extensions">The extensions.</param>
     /// <returns>A <see cref="ValidationErrorInstance"/>.</returns>
-    public static ValidationErrorInstance Create(ValidationErrorDescriptor descriptor, ImmutableArray<string> paths, ImmutableArray<KeyValuePair<string, string>> extensions) 
+    public static ValidationErrorInstance Create(ValidationErrorDescriptor descriptor, ImmutableArray<string> paths, ProblemExtensionData extensions) 
         => new ValidationErrorInstance(descriptor, paths: paths, extensions: extensions);
 
     /// <summary>
@@ -107,7 +109,7 @@ public sealed class ValidationErrorInstance
     /// <param name="paths">The paths.</param>
     /// <param name="extensions">The extensions.</param>
     /// <returns>A <see cref="ValidationErrorInstance"/>.</returns>
-    public static ValidationErrorInstance Create(ValidationErrorDescriptor descriptor, IEnumerable<string> paths, ImmutableArray<KeyValuePair<string, string>> extensions) 
+    public static ValidationErrorInstance Create(ValidationErrorDescriptor descriptor, IEnumerable<string> paths, ProblemExtensionData extensions) 
         => new ValidationErrorInstance(descriptor, paths: [.. paths], extensions: extensions);
 
     /// <summary>
@@ -122,7 +124,7 @@ public sealed class ValidationErrorInstance
 
     private readonly ValidationErrorDescriptor _descriptor;
     private readonly ImmutableArray<string> _paths;
-    private readonly ImmutableArray<KeyValuePair<string, string>> _extensions;
+    private readonly ProblemExtensionData _extensions;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ValidationErrorInstance"/> class.
@@ -133,7 +135,7 @@ public sealed class ValidationErrorInstance
     internal ValidationErrorInstance(
         ValidationErrorDescriptor descriptor, 
         ImmutableArray<string> paths, 
-        ImmutableArray<KeyValuePair<string, string>> extensions)
+        ProblemExtensionData extensions)
     {
         _descriptor = descriptor;
         _paths = paths;
@@ -157,7 +159,7 @@ public sealed class ValidationErrorInstance
     /// <summary>
     /// Gets the extensions.
     /// </summary>
-    public ImmutableArray<KeyValuePair<string, string>> Extensions => _extensions;
+    public ProblemExtensionData Extensions => _extensions;
 
     /// <summary>
     /// Implicitly converts a <see cref="ProblemDescriptor"/> to a <see cref="ProblemInstance"/>.

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ValidationProblemInstance.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ValidationProblemInstance.cs
@@ -1,0 +1,29 @@
+﻿using CommunityToolkit.Diagnostics;
+using System.Collections.Immutable;
+
+namespace Altinn.Authorization.ProblemDetails;
+
+/// <summary>
+/// A problem instance of a validation problem, containing 1 or more validation errors. Created using
+/// a <see cref="ValidationErrorBuilder"/>.
+/// </summary>
+public sealed record ValidationProblemInstance
+    : ProblemInstance
+{
+    private readonly ImmutableArray<ValidationErrorInstance> _errors;
+
+    internal ValidationProblemInstance(
+        ImmutableArray<ValidationErrorInstance> errors,
+        ProblemExtensionData extensions)
+        : base(StdProblemDescriptors.ValidationError, extensions)
+    {
+        Guard.IsNotEmpty(errors.AsSpan(), nameof(errors));
+
+        _errors = errors;
+    }
+
+    /// <summary>
+    /// Gets the validation errors.
+    /// </summary>
+    public ImmutableArray<ValidationErrorInstance> Errors => _errors;
+}

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails/AltinnProblemDetails.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails/AltinnProblemDetails.cs
@@ -32,10 +32,7 @@ public class AltinnProblemDetails
 
         if (!instance.Extensions.IsDefaultOrEmpty)
         {
-            foreach (var (key, value) in instance.Extensions)
-            {
-                Extensions[key] = value;
-            }
+            Extensions = instance.Extensions;
         }
     }
 

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails/AltinnValidationError.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails/AltinnValidationError.cs
@@ -30,10 +30,7 @@ public sealed class AltinnValidationError
 
         if (!instance.Extensions.IsDefaultOrEmpty)
         {
-            foreach (var (key, value) in instance.Extensions)
-            {
-                Extensions[key] = value;
-            }
+            Extensions = instance.Extensions;
         }
     }
 

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails/AltinnValidationProblemDetails.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails/AltinnValidationProblemDetails.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Immutable;
+using System.Text.Json.Serialization;
 
 namespace Altinn.Authorization.ProblemDetails;
 
@@ -8,6 +9,31 @@ namespace Altinn.Authorization.ProblemDetails;
 public sealed class AltinnValidationProblemDetails
     : AltinnProblemDetails
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AltinnValidationProblemDetails"/> class from a
+    /// <see cref="ValidationProblemInstance"/>.
+    /// </summary>
+    /// <param name="instance">The <see cref="ValidationProblemInstance"/>.</param>
+    internal AltinnValidationProblemDetails(ValidationProblemInstance instance)
+        : base(instance)
+    {
+        var errors = instance.Errors;
+        if (!errors.IsDefaultOrEmpty)
+        {
+            var builder = ImmutableArray.CreateBuilder<AltinnValidationError>(errors.Length);
+            foreach (var error in errors)
+            {
+                builder.Add(new AltinnValidationError(error));
+            }
+
+            Errors = builder.ToImmutable();
+        }
+        else
+        {
+            Errors = [];
+        }
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="AltinnValidationProblemDetails"/> class.
     /// </summary>

--- a/src/Altinn.Authorization.ProblemDetails/test/ProblemDetails.Tests/ProblemExtensionDataTests.cs
+++ b/src/Altinn.Authorization.ProblemDetails/test/ProblemDetails.Tests/ProblemExtensionDataTests.cs
@@ -1,0 +1,255 @@
+﻿using System.Collections.Immutable;
+
+namespace Altinn.Authorization.ProblemDetails.Tests;
+
+public class ProblemExtensionDataTests
+{
+    [Fact]
+    public static void Default_AreEqual()
+    {
+        AssertEqual(default, default);
+    }
+
+    [Fact]
+    public static void Empty_AreEqual()
+    {
+        AssertEqual(ProblemExtensionData.Empty, ProblemExtensionData.Empty);
+    }
+
+    [Fact]
+    public static void Default_And_Empty_AreEqual()
+    {
+        AssertEqual(default, ProblemExtensionData.Empty);
+    }
+
+    [Fact]
+    public static void SingleItem_Equal_AreEqual()
+    {
+        ProblemExtensionData expected = [
+            KeyValuePair.Create("key", "value"),
+        ];
+
+        ProblemExtensionData actual = [
+            KeyValuePair.Create("key", "value"),
+        ];
+
+        AssertEqual(expected, actual);
+    }
+
+    [Fact]
+    public static void SingleItem_DifferentValue_AreNotEqual()
+    {
+        ProblemExtensionData expected = [
+            KeyValuePair.Create("key", "value"),
+        ];
+
+        ProblemExtensionData actual = [
+            KeyValuePair.Create("key", "value 2"),
+        ];
+
+        AssertNotEqual(expected, actual);
+    }
+
+    [Fact]
+    public static void SingleItem_DifferentKey_AreNotEqual()
+    {
+        ProblemExtensionData expected = [
+            KeyValuePair.Create("key", "value"),
+        ];
+
+        ProblemExtensionData actual = [
+            KeyValuePair.Create("key-2", "value"),
+        ];
+
+        AssertNotEqual(expected, actual);
+    }
+
+    [Fact]
+    public static void SingleItem_DifferentKeyAndValue_AreNotEqual()
+    {
+        ProblemExtensionData expected = [
+            KeyValuePair.Create("key", "value"),
+        ];
+
+        ProblemExtensionData actual = [
+            KeyValuePair.Create("key-2", "value 2"),
+        ];
+
+        AssertNotEqual(expected, actual);
+    }
+
+    [Fact]
+    public static void MultipleItems_Equal_SameOrder_AreEqual()
+    {
+        ProblemExtensionData expected = [
+            KeyValuePair.Create("key", "value"),
+            KeyValuePair.Create("key-2", "value 2"),
+        ];
+
+        ProblemExtensionData actual = [
+            KeyValuePair.Create("key", "value"),
+            KeyValuePair.Create("key-2", "value 2"),
+        ];
+
+        AssertEqual(expected, actual);
+    }
+
+    [Fact]
+    public static void MultipleItems_Equal_DifferentOrder_AreEqual()
+    {
+        ProblemExtensionData expected = [
+            KeyValuePair.Create("key", "value"),
+            KeyValuePair.Create("key-2", "value 2"),
+        ];
+
+        ProblemExtensionData actual = [
+            KeyValuePair.Create("key-2", "value 2"),
+            KeyValuePair.Create("key", "value"),
+        ];
+
+        AssertEqual(expected, actual);
+    }
+
+    [Fact]
+    public static void MultipleItems_Different_AreNotEqual()
+    {
+        ProblemExtensionData expected = [
+            KeyValuePair.Create("key", "value"),
+            KeyValuePair.Create("key-2", "value 2"),
+        ];
+
+        ProblemExtensionData actual = [
+            KeyValuePair.Create("key-2", "not value"),
+            KeyValuePair.Create("key", "value"),
+        ];
+
+        AssertNotEqual(expected, actual);
+    }
+
+    [Fact]
+    public static void MultipleItems_SameKey_DifferentOrder_AreEqual()
+    {
+        ProblemExtensionData expected = [
+            KeyValuePair.Create("key", "value"),
+            KeyValuePair.Create("key", "value 2"),
+        ];
+
+        ProblemExtensionData actual = [
+            KeyValuePair.Create("key", "value 2"),
+            KeyValuePair.Create("key", "value"),
+        ];
+
+        AssertEqual(expected, actual);
+    }
+
+    [Fact]
+    public static void MultipleItems_SameKey_SameOrder_AreEqual()
+    {
+        ProblemExtensionData expected = [
+            KeyValuePair.Create("key", "value"),
+            KeyValuePair.Create("key", "value 2"),
+        ];
+
+        ProblemExtensionData actual = [
+            KeyValuePair.Create("key", "value"),
+            KeyValuePair.Create("key", "value 2"),
+        ];
+
+        AssertEqual(expected, actual);
+    }
+
+    [Fact]
+    public static void MoreThan50Items_AreEqual()
+    {
+        var builder = ImmutableArray.CreateBuilder<KeyValuePair<string, string>>();
+        for (var i = 0; i < 100; i++)
+        {
+            builder.Add(KeyValuePair.Create($"key-{i}", $"value-{i}"));
+        }
+
+        ProblemExtensionData expected = builder.ToImmutable();
+
+        // this sorts alphabetically by the key, thus key-11 will be before key-2
+        builder.Sort((x, y) => string.Compare(x.Key, y.Key, StringComparison.Ordinal));
+
+        ProblemExtensionData actual = builder.ToImmutable();
+
+        AssertEqual(expected, actual);
+    }
+
+    [Fact]
+    public static void Empty_KeyLookup_DoesNotThrow()
+    {
+        var data = ProblemExtensionData.Empty;
+
+        var values = data["key"];
+        Assert.Empty(values);
+    }
+
+    [Fact]
+    public static void MultipleItems_SameKey_KeyLookup_ReturnsAllMatchingValues()
+    {
+        ProblemExtensionData data = [
+            KeyValuePair.Create("first key", "first value"),
+            KeyValuePair.Create("key", "value"),
+            KeyValuePair.Create("key", "value 2"),
+            KeyValuePair.Create("other key", "other value"),
+        ];
+
+        var values = data["key"];
+        Assert.Collection(values,
+            value => Assert.Equal("value", value),
+            value => Assert.Equal("value 2", value));
+    }
+
+    [Fact]
+    public static void Dictionary_Values_Tests()
+    {
+        ProblemExtensionData data = [
+            KeyValuePair.Create("first key", "first value"),
+            KeyValuePair.Create("key", "value"),
+            KeyValuePair.Create("key", "value 2"),
+            KeyValuePair.Create("other key", "other value"),
+        ];
+
+        var values = (data as IDictionary<string, object?>).Values;
+        values.Should().HaveCount(4);
+        values.Should().BeEquivalentTo(["first value", "value", "value 2", "other value"]);
+        values.IsReadOnly.Should().BeTrue();
+        values.Contains("value").Should().BeTrue();
+    }
+
+    [Fact]
+    public static void Dictionary_Keys_Tests()
+    {
+        ProblemExtensionData data = [
+            KeyValuePair.Create("first key", "first value"),
+            KeyValuePair.Create("key", "value"),
+            KeyValuePair.Create("key", "value 2"),
+            KeyValuePair.Create("other key", "other value"),
+        ];
+
+        var keys = (data as IDictionary<string, object?>).Keys;
+        keys.Should().HaveCount(4);
+        keys.Should().BeEquivalentTo(["first key", "key", "key", "other key"]);
+        keys.IsReadOnly.Should().BeTrue();
+        keys.Contains("key").Should().BeTrue();
+    }
+
+    private static void AssertEqual(ProblemExtensionData expected, ProblemExtensionData actual)
+    {
+        Assert.Equal(expected, actual);
+        Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+        Assert.True(expected.Equals(actual));
+        Assert.True(expected == actual);
+        Assert.False(expected != actual);
+    }
+
+    private static void AssertNotEqual(ProblemExtensionData expected, ProblemExtensionData actual)
+    {
+        Assert.NotEqual(expected, actual);
+        Assert.False(expected.Equals(actual));
+        Assert.False(expected == actual);
+        Assert.True(expected != actual);
+    }
+}

--- a/src/Altinn.Authorization.ProblemDetails/test/ProblemDetails.Tests/ResultTests.cs
+++ b/src/Altinn.Authorization.ProblemDetails/test/ProblemDetails.Tests/ResultTests.cs
@@ -1,0 +1,97 @@
+﻿namespace Altinn.Authorization.ProblemDetails.Tests;
+
+public class ResultTests
+{
+    public static TheoryData<Result<ErrorCode>, ErrorCode> ErrorCodeResults => new()
+    {
+        { StdProblemDescriptors.ErrorCodes.ValidationError, StdProblemDescriptors.ErrorCodes.ValidationError },
+        { StdProblemDescriptors.ValidationError, StdProblemDescriptors.ErrorCodes.ValidationError },
+    };
+
+    [Theory]
+    [MemberData(nameof(ErrorCodeResults))]
+    public void CanPatternMatch_OrderIndependent(Result<ErrorCode> input, ErrorCode expected)
+    {
+        ErrorCode actual;
+
+        // IsSuccess check
+        actual = input switch
+        {
+            { IsSuccess: true } => input.Value,
+            _ => input.Problem.ErrorCode,
+        };
+
+        actual.Should().Be(expected);
+
+        // IsProblem check
+        actual = input switch
+        {
+            { IsProblem: true } => input.Problem.ErrorCode,
+            _ => input.Value,
+        };
+
+        actual.Should().Be(expected);
+
+        // Using the 'is' pattern with IsSuccess
+        if (input is { IsSuccess: true })
+        {
+            actual = input.Value;
+        }
+        else
+        {
+            actual = input.Problem.ErrorCode;
+        }
+
+        actual.Should().Be(expected);
+
+        // Using the 'is' pattern with IsProblem
+        if (input is { IsProblem: true })
+        {
+            actual = input.Problem.ErrorCode;
+        }
+        else
+        {
+            actual = input.Value;
+        }
+
+        actual.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ValidationTestCase(bool fail)
+    {
+        var result = TrySomething(fail);
+        result.IsProblem.Should().Be(fail);
+
+        if (result.IsProblem)
+        {
+            result.Problem.ErrorCode.Should().Be(StdProblemDescriptors.ErrorCodes.ValidationError);
+            result.Problem.Should().BeOfType<ValidationProblemInstance>()
+                .Which.Errors.Should().ContainSingle()
+                .Which.ErrorCode.Should().Be(StdValidationErrors.ErrorCodes.Required);
+        }
+        else
+        {
+            result.Value.Should().Be(42);
+        }
+
+        static Result<int> TrySomething(bool fail)
+        {
+            ValidationErrorBuilder errors = new();
+
+            if (fail)
+            {
+                errors.Add(StdValidationErrors.Required, "/field");
+            }
+
+            if (errors.TryBuild(out var errorInstance))
+            {
+                return errorInstance;
+            }
+
+            return 42;
+        }
+    }
+}

--- a/src/Altinn.Authorization.ProblemDetails/test/ProblemDetails.Tests/ResultTests.cs
+++ b/src/Altinn.Authorization.ProblemDetails/test/ProblemDetails.Tests/ResultTests.cs
@@ -2,59 +2,58 @@
 
 public class ResultTests
 {
-    public static TheoryData<Result<ErrorCode>, ErrorCode> ErrorCodeResults => new()
+    [Fact]
+    public void CanPatternMatch_OrderIndependent()
     {
-        { StdProblemDescriptors.ErrorCodes.ValidationError, StdProblemDescriptors.ErrorCodes.ValidationError },
-        { StdProblemDescriptors.ValidationError, StdProblemDescriptors.ErrorCodes.ValidationError },
-    };
+        Test(StdProblemDescriptors.ErrorCodes.ValidationError, StdProblemDescriptors.ErrorCodes.ValidationError);
+        Test(StdProblemDescriptors.ValidationError, StdProblemDescriptors.ErrorCodes.ValidationError);
 
-    [Theory]
-    [MemberData(nameof(ErrorCodeResults))]
-    public void CanPatternMatch_OrderIndependent(Result<ErrorCode> input, ErrorCode expected)
-    {
-        ErrorCode actual;
-
-        // IsSuccess check
-        actual = input switch
+        static void Test(Result<ErrorCode> input, ErrorCode expected)
         {
-            { IsSuccess: true } => input.Value,
-            _ => input.Problem.ErrorCode,
-        };
+            ErrorCode actual;
 
-        actual.Should().Be(expected);
+            // IsSuccess check
+            actual = input switch
+            {
+                { IsSuccess: true } => input.Value,
+                _ => input.Problem.ErrorCode,
+            };
 
-        // IsProblem check
-        actual = input switch
-        {
-            { IsProblem: true } => input.Problem.ErrorCode,
-            _ => input.Value,
-        };
+            actual.Should().Be(expected);
 
-        actual.Should().Be(expected);
+            // IsProblem check
+            actual = input switch
+            {
+                { IsProblem: true } => input.Problem.ErrorCode,
+                _ => input.Value,
+            };
 
-        // Using the 'is' pattern with IsSuccess
-        if (input is { IsSuccess: true })
-        {
-            actual = input.Value;
+            actual.Should().Be(expected);
+
+            // Using the 'is' pattern with IsSuccess
+            if (input is { IsSuccess: true })
+            {
+                actual = input.Value;
+            }
+            else
+            {
+                actual = input.Problem.ErrorCode;
+            }
+
+            actual.Should().Be(expected);
+
+            // Using the 'is' pattern with IsProblem
+            if (input is { IsProblem: true })
+            {
+                actual = input.Problem.ErrorCode;
+            }
+            else
+            {
+                actual = input.Value;
+            }
+
+            actual.Should().Be(expected);
         }
-        else
-        {
-            actual = input.Problem.ErrorCode;
-        }
-
-        actual.Should().Be(expected);
-
-        // Using the 'is' pattern with IsProblem
-        if (input is { IsProblem: true })
-        {
-            actual = input.Problem.ErrorCode;
-        }
-        else
-        {
-            actual = input.Value;
-        }
-
-        actual.Should().Be(expected);
     }
 
     [Theory]

--- a/src/Altinn.Authorization.ProblemDetails/test/ProblemDetails.Tests/ValidationErrorsTests.cs
+++ b/src/Altinn.Authorization.ProblemDetails/test/ProblemDetails.Tests/ValidationErrorsTests.cs
@@ -28,26 +28,33 @@ public class ValidationErrorsTests
     }
 
     [Fact]
-    public void CanMapToImmutableArray()
+    public void Empty_TryTo_Returns_False()
+    {
+        var errors = new ValidationErrorBuilder();
+
+        errors.TryBuild(out var instance).Should().BeFalse();
+        errors.TryToProblemDetails(out var details).Should().BeFalse();
+        errors.TryToActionResult(out var result).Should().BeFalse();
+
+        instance.Should().BeNull();
+        details.Should().BeNull();
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Errors_TryTo_Returns_True()
     {
         var errors = new ValidationErrorBuilder();
 
         errors.Add(StdValidationErrors.Required, "/path");
         errors.Add(StdValidationErrors.Required, "/path2");
 
-        var immutable = errors.MapToImmutable(static v => v);
-        immutable.Should().HaveCount(2);
-    }
+        errors.TryBuild(out var instance).Should().BeTrue();
+        errors.TryToProblemDetails(out var details).Should().BeTrue();
+        errors.TryToActionResult(out var result).Should().BeTrue();
 
-    [Fact]
-    public void Empty_TryTo_Returns_False()
-    {
-        var errors = new ValidationErrorBuilder();
-
-        errors.TryToProblemDetails(out var details).Should().BeFalse();
-        errors.TryToActionResult(out var result).Should().BeFalse();
-
-        details.Should().BeNull();
-        result.Should().BeNull();
+        instance.Should().NotBeNull();
+        details.Should().NotBeNull();
+        result.Should().NotBeNull();
     }
 }


### PR DESCRIPTION
Refactors the ProblemDetails.Abstractions a fair bit, and adds a Result class to represent the result of a request. This is a way to return a result from a request that is either a success or a problem details response.

feat: create ValidationProblemInstance in ProblemDetails.Abstractions.

refactor: move ValidationErrorBuilder to ProblemDetails.Abstractions
  BREAKING-CHANGE: The ValidationErrorBuilder class has been moved to
  the ProblemDetails.Abstractions assembly.

feat: add ProblemExtensionData to ProblemDetails.Abstractions
  BREAKING-CHANGE: The various Extensions properties in
  ProblemDetails.Abstractions have been changed from being a immutable
  array of key-value pairs, to a new ProblemExtensionData type.

refactor: unseal ProblemInstance

chore: add DebuggerDisplay attributes to multiple types

