### PR TITLE
chore: drop .NET 8 support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,11 +19,6 @@
         <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="9.10.0" />
       </ItemGroup>
     </When>
-    <When Condition=" '$(TargetFramework)' == 'net8.0' ">
-      <ItemGroup>
-        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.27" />
-      </ItemGroup>
-    </When>
   </Choose>
   <ItemGroup>
     <PackageVersion Include="Altinn.Common.AccessTokenClient" Version="3.2.8" />

--- a/src/Altinn.Authorization.ModelUtils/sample/ModelUtils.Sample.Api/Models/Enums.cs
+++ b/src/Altinn.Authorization.ModelUtils/sample/ModelUtils.Sample.Api/Models/Enums.cs
@@ -45,13 +45,11 @@ public static class Enums
         /// </summary>
         OtherValue3,
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Custom value 4.
         /// </summary>
         [JsonStringEnumMemberName("custom")]
         CustomValue4,
-#endif
     }
 
     /// <summary>
@@ -75,13 +73,11 @@ public static class Enums
         /// </summary>
         OtherValue3,
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Custom value 4.
         /// </summary>
         [JsonStringEnumMemberName("custom")]
         CustomValue4,
-#endif
     }
 
     /// <summary>
@@ -105,13 +101,11 @@ public static class Enums
         /// </summary>
         OtherValue3,
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Custom value 4.
         /// </summary>
         [JsonStringEnumMemberName("custom")]
         CustomValue4,
-#endif
     }
 
     /// <summary>
@@ -135,13 +129,11 @@ public static class Enums
         /// </summary>
         OtherValue3,
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Custom value 4.
         /// </summary>
         [JsonStringEnumMemberName("custom")]
         CustomValue4,
-#endif
     }
 
     /// <summary>
@@ -165,13 +157,11 @@ public static class Enums
         /// </summary>
         OtherValue3,
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Custom value 4.
         /// </summary>
         [JsonStringEnumMemberName("custom")]
         CustomValue4,
-#endif
     }
 
     /// <summary>
@@ -195,13 +185,11 @@ public static class Enums
         /// </summary>
         OtherValue3,
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Custom value 4.
         /// </summary>
         [JsonStringEnumMemberName("custom")]
         CustomValue4,
-#endif
     }
 
     /// <summary>
@@ -225,13 +213,11 @@ public static class Enums
         /// </summary>
         OtherValue3,
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Custom value 4.
         /// </summary>
         [JsonStringEnumMemberName("custom")]
         CustomValue4,
-#endif
     }
 
     /// <summary>

--- a/src/Altinn.Authorization.ModelUtils/src/ModelUtils.Swashbuckle/NonExhaustiveEnumSchemaFilter.cs
+++ b/src/Altinn.Authorization.ModelUtils/src/ModelUtils.Swashbuckle/NonExhaustiveEnumSchemaFilter.cs
@@ -42,12 +42,7 @@ internal sealed class NonExhaustiveEnumSchemaFilter
                 return () => httpJsonOptions.CurrentValue.SerializerOptions;
             }
 
-#if NET9_0_OR_GREATER
             return () => JsonSerializerOptions.Web;
-#else
-            var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-            return () => options;
-#endif
         });
     }
 

--- a/src/Altinn.Authorization.ModelUtils/test/ModelUtils.Tests/Utils/Enums.cs
+++ b/src/Altinn.Authorization.ModelUtils/test/ModelUtils.Tests/Utils/Enums.cs
@@ -66,12 +66,10 @@ public static class Enums
     private static string GetExpected(object value, Type type, JsonNamingPolicy? namingPolicy)
     {
         var name = value.ToString().ShouldNotBeNull();
-#if NET9_0_OR_GREATER
         if (type.GetField(name, BindingFlags.Public | BindingFlags.Static)?.GetCustomAttribute<JsonStringEnumMemberNameAttribute>() is { } nameAttr)
         {
             return nameAttr.Name.ShouldNotBeNull();
         }
-#endif
 
         return namingPolicy?.ConvertName(name) ?? name;
     }
@@ -279,13 +277,11 @@ public static class Enums
         /// </summary>
         OtherValue3,
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Custom value 4.
         /// </summary>
         [JsonStringEnumMemberName("custom")]
         CustomValue4,
-#endif
     }
 
     /// <summary>
@@ -309,13 +305,11 @@ public static class Enums
         /// </summary>
         OtherValue3,
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Custom value 4.
         /// </summary>
         [JsonStringEnumMemberName("custom")]
         CustomValue4,
-#endif
     }
 
     /// <summary>
@@ -339,13 +333,11 @@ public static class Enums
         /// </summary>
         OtherValue3,
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Custom value 4.
         /// </summary>
         [JsonStringEnumMemberName("custom")]
         CustomValue4,
-#endif
     }
 
     /// <summary>
@@ -369,13 +361,11 @@ public static class Enums
         /// </summary>
         OtherValue3,
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Custom value 4.
         /// </summary>
         [JsonStringEnumMemberName("custom")]
         CustomValue4,
-#endif
     }
 
     /// <summary>
@@ -399,13 +389,11 @@ public static class Enums
         /// </summary>
         OtherValue3,
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Custom value 4.
         /// </summary>
         [JsonStringEnumMemberName("custom")]
         CustomValue4,
-#endif
     }
 
     /// <summary>
@@ -429,13 +417,11 @@ public static class Enums
         /// </summary>
         OtherValue3,
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Custom value 4.
         /// </summary>
         [JsonStringEnumMemberName("custom")]
         CustomValue4,
-#endif
     }
 
     /// <summary>
@@ -459,12 +445,10 @@ public static class Enums
         /// </summary>
         OtherValue3,
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Custom value 4.
         /// </summary>
         [JsonStringEnumMemberName("custom")]
         CustomValue4,
-#endif
     }
 }

--- a/src/Altinn.Authorization.ModelUtils/test/ModelUtils.Tests/Utils/Json.cs
+++ b/src/Altinn.Authorization.ModelUtils/test/ModelUtils.Tests/Utils/Json.cs
@@ -9,11 +9,7 @@ namespace Altinn.Authorization.ModelUtils.Tests.Utils;
 
 public static class Json
 {
-#if NET9_0_OR_GREATER
     private readonly static JsonSerializerOptions _options = JsonSerializerOptions.Web;
-#else
-    private readonly static JsonSerializerOptions _options = new(JsonSerializerDefaults.Web);
-#endif
 
     public static JsonSerializerOptions Options => _options;
 

--- a/src/Altinn.Authorization.ProblemDetails/Directory.Build.props
+++ b/src/Altinn.Authorization.ProblemDetails/Directory.Build.props
@@ -3,7 +3,7 @@
     Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ErrorCodeTracking.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Abstractions/ErrorCodeTracking.cs
@@ -10,11 +10,7 @@ namespace Altinn.Authorization.ProblemDetails;
 internal sealed class ErrorCodeTracking
 {
     private readonly HashSet<uint> _usedCodes = new();
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ErrorCodeTracking"/> class.

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Validation/DelegateValidator.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Validation/DelegateValidator.cs
@@ -10,9 +10,7 @@ namespace Altinn.Authorization.ProblemDetails.Validation;
 /// <typeparam name="TOut">The type of the output model.</typeparam>
 public readonly struct DelegateValidator<TIn, TOut>
     : IValidator<TIn, TOut>
-#if NET9_0_OR_GREATER
         where TIn : allows ref struct
-#endif
         where TOut : notnull
 {
     private readonly Validator<TIn, TOut> _validator;

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Validation/IInputModel.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Validation/IInputModel.cs
@@ -7,11 +7,7 @@ namespace Altinn.Authorization.ProblemDetails.Validation;
 /// </summary>
 /// <typeparam name="TValidated">The validated model type.</typeparam>
 public interface IInputModel<TValidated>
-#if NET9_0_OR_GREATER
     where TValidated : notnull, allows ref struct
-#else
-    where TValidated : notnull
-#endif
 {
     /// <summary>
     /// Validates the input model and produces a validated representation.

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Validation/IValidator.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Validation/IValidator.cs
@@ -8,12 +8,8 @@ namespace Altinn.Authorization.ProblemDetails.Validation;
 /// <typeparam name="TIn">The type of the input model.</typeparam>
 /// <typeparam name="TOut">The type of the validated model.</typeparam>
 public interface IValidator<TIn, TOut>
-#if NET9_0_OR_GREATER
     where TIn : allows ref struct
     where TOut : notnull
-#else
-    where TOut : notnull
-#endif
 {
     /// <summary>
     /// Tries to validate the input model and produce a validated output model.

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Validation/InputModelValidator.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Validation/InputModelValidator.cs
@@ -9,13 +9,8 @@ namespace Altinn.Authorization.ProblemDetails.Validation;
 /// <typeparam name="TOut">The type of the output model.</typeparam>
 public readonly struct InputModelValidator<TIn, TOut>
     : IValidator<TIn, TOut>
-#if NET9_0_OR_GREATER
     where TIn : IInputModel<TOut>?, allows ref struct
     where TOut : notnull
-#else
-    where TIn : IInputModel<TOut>?
-    where TOut : notnull
-#endif
 {
     /// <inheritdoc/>
     public bool TryValidate(ref ValidationContext context, TIn input, [NotNullWhen(true)] out TOut? validated)

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Validation/ValidationContext.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Validation/ValidationContext.cs
@@ -18,14 +18,9 @@ public ref struct ValidationContext
         TIn input,
         TValidator validator,
         [NotNullWhen(true)] out TOut? validated)
-#if NET9_0_OR_GREATER
         where TIn : allows ref struct
         where TOut : notnull
         where TValidator : IValidator<TIn, TOut>
-#else
-        where TOut : notnull
-        where TValidator : IValidator<TIn, TOut>
-#endif
     {
         Guard.IsNotNull(validator);
         Guard.IsValidRootPath(path);
@@ -91,12 +86,8 @@ public ref struct ValidationContext
         TIn input,
         Validator<TIn, TOut> validator,
         [NotNullWhen(true)] out TOut? validated)
-#if NET9_0_OR_GREATER
         where TIn : allows ref struct
         where TOut : notnull
-#else
-        where TOut : notnull
-#endif
         => TryValidateChild(path, input, new DelegateValidator<TIn, TOut>(validator), out validated);
 
     /// <summary>
@@ -116,14 +107,9 @@ public ref struct ValidationContext
         TIn input,
         TValidator validator,
         [NotNullWhen(true)] out TOut? validated)
-#if NET9_0_OR_GREATER
         where TIn : allows ref struct
         where TOut : notnull
         where TValidator : IValidator<TIn, TOut>
-#else
-        where TOut : notnull
-        where TValidator : IValidator<TIn, TOut>
-#endif
     {
         Debug.Assert(!_state.HasFlag(ValidationState.IsDisposed));
         var parentHandle = _root.Acquire(_handle, path);
@@ -509,10 +495,6 @@ public delegate bool Validator<in TIn, TOut>(
     ref ValidationContext context,
     TIn input,
     [NotNullWhen(true)] out TOut? validated)
-#if NET9_0_OR_GREATER
     where TIn : allows ref struct
     where TOut : notnull, allows ref struct
-#else
-        where TOut : notnull
-#endif
     ;

--- a/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Validation/ValidationExtensions.cs
+++ b/src/Altinn.Authorization.ProblemDetails/src/ProblemDetails.Validation/ValidationExtensions.cs
@@ -24,13 +24,8 @@ public static class ValidationExtensions
             string path,
             TIn? input,
             [NotNullWhen(true)] out TOut? validated)
-#if NET9_0_OR_GREATER
             where TIn : notnull, IInputModel<TOut>, allows ref struct
             where TOut : notnull
-#else
-            where TIn : notnull, IInputModel<TOut>
-            where TOut : notnull
-#endif
         {
             return context.TryValidateChild(
                 path,
@@ -66,13 +61,8 @@ public static class ValidationExtensions
     /// <typeparam name="TOut">The type of the validated model.</typeparam>
     /// <param name="model">The input model to validate.</param>
     extension<TIn, TOut>(TIn model)
-#if NET9_0_OR_GREATER
         where TIn : notnull, IInputModel<TOut>, allows ref struct
         where TOut : notnull
-#else
-        where TIn : notnull, IInputModel<TOut>
-        where TOut : notnull
-#endif
     {
         /// <summary>
         /// Tries to validate the input model and produce a validated output model.
@@ -107,14 +97,9 @@ public static class ValidationExtensions
     /// <typeparam name="TValidator">The type of the custom validator.</typeparam>
     /// <param name="validator">The custom validator to use.</param>
     extension<TIn, TOut, TValidator>(TValidator validator)
-#if NET9_0_OR_GREATER
         where TIn : allows ref struct
         where TOut : notnull
         where TValidator : IValidator<TIn, TOut>
-#else
-        where TOut : notnull
-        where TValidator : IValidator<TIn, TOut>
-#endif
     {
         /// <summary>
         /// Tries to validate the input model using the custom validator and produce a validated output model.
@@ -163,13 +148,8 @@ public static class ValidationExtensions
             string path,
             TIn? input,
             [NotNullWhen(true)] out TOut? validated)
-#if NET9_0_OR_GREATER
             where TIn : notnull, IInputModel<TOut>, allows ref struct
             where TOut : notnull
-#else
-            where TIn : notnull, IInputModel<TOut>
-            where TOut : notnull
-#endif
         {
             return builder.TryValidate(
                 path,
@@ -195,14 +175,9 @@ public static class ValidationExtensions
             TIn input,
             TValidator validator,
             [NotNullWhen(true)] out TOut? validated)
-#if NET9_0_OR_GREATER
             where TIn : allows ref struct
             where TOut : notnull
             where TValidator : IValidator<TIn, TOut>
-#else
-            where TOut : notnull
-            where TValidator : IValidator<TIn, TOut>
-#endif
         {
             return ValidationContext.TryValidate(
                 ref builder,
@@ -228,12 +203,8 @@ public static class ValidationExtensions
             TIn input,
             Validator<TIn, TOut> validator,
             [NotNullWhen(true)] out TOut? validated)
-#if NET9_0_OR_GREATER
             where TIn : allows ref struct
             where TOut : notnull
-#else
-            where TOut : notnull
-#endif
         {
             return builder.TryValidate(
                 path,

--- a/src/Altinn.Authorization.ProblemDetails/test/ProblemDetails.Tests/JsonSnapshotTests.cs
+++ b/src/Altinn.Authorization.ProblemDetails/test/ProblemDetails.Tests/JsonSnapshotTests.cs
@@ -16,11 +16,7 @@ public class JsonSnapshotTests
     private static readonly ValidationErrorDescriptor _invalid = _validations.Create(0, "Invalid value");
 
     protected static JsonSerializerOptions Options { get; }
-#if NET9_0_OR_GREATER
         = JsonSerializerOptions.Web;
-#else
-        = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-#endif
 
     private static JsonWriterOptions WriterOptions { get; }
         = new JsonWriterOptions

--- a/src/Altinn.Authorization.ProblemDetails/test/ProblemDetails.Tests/Validation/ListValidationTests.cs
+++ b/src/Altinn.Authorization.ProblemDetails/test/ProblemDetails.Tests/Validation/ListValidationTests.cs
@@ -205,10 +205,8 @@ public class ListValidationTests
 
     private readonly struct NonNullStringValidator
         : IValidator<string?, NonNullString>
-#if NET9_0_OR_GREATER
         // Note: this is here just to make sure it keeps compiling
         , IValidator<ReadOnlySpan<char>, NonNullString>
-#endif
     {
         public bool TryValidate(ref ValidationContext context, string? input, [NotNullWhen(true)] out NonNullString? validated)
         {

--- a/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults.Authorization/Altinn.Authorization.ServiceDefaults.Authorization.csproj
+++ b/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults.Authorization/Altinn.Authorization.ServiceDefaults.Authorization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net10.0;net9.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -11,7 +11,7 @@
 	<ItemGroup>
 		<PackageReference Include="Azure.Identity" />
 		<PackageReference Include="Azure.Security.KeyVault.Secrets" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Condition=" '$(TargetFramework)' != 'net8.0' " />
+		<PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
 		<PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
 		<PackageReference Include="System.Linq.AsyncEnumerable" />
 	</ItemGroup>

--- a/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults.Authorization/Microsoft.AspNetCore.Authorization/AltinnAuthorizationPolicyBuilderExtensions.cs
+++ b/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults.Authorization/Microsoft.AspNetCore.Authorization/AltinnAuthorizationPolicyBuilderExtensions.cs
@@ -15,7 +15,6 @@ public static class AltinnAuthorizationPolicyBuilderExtensions
     extension(AuthorizationPolicyBuilder builder)
     {
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Adds a requirement to the authorization policy that at least one of the specified scopes must be present in the
         /// user's claims.
@@ -35,7 +34,6 @@ public static class AltinnAuthorizationPolicyBuilderExtensions
             builder.Requirements.Add(new ScopeAnyOfAuthorizationRequirement(scopes));
             return builder;
         }
-#endif
 
         /// <summary>
         /// Adds a requirement to the authorization policy that at least one of the specified scopes must be present in the
@@ -77,7 +75,6 @@ public static class AltinnAuthorizationPolicyBuilderExtensions
             return builder;
         }
 
-#if NET9_0_OR_GREATER
         /// <summary>
         /// Adds a requirement to the authorization policy that at least one of the specified scopes must be present in the
         /// user's claims, *or* that a platform-access-token is included in the request.
@@ -118,7 +115,6 @@ public static class AltinnAuthorizationPolicyBuilderExtensions
             builder.Requirements.Add(new PlatformAccessTokenOrScopeAnyOfAuthorizationRequirement(approvedIssuers, scopes));
             return builder;
         }
-#endif
 
         /// <summary>
         /// Adds a requirement to the authorization policy that at least one of the specified scopes must be present in the

--- a/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults.Authorization/Microsoft.Extensions.DependencyInjection/AltinnServiceDefaultsAuthorizationServiceCollectionExtensions.cs
+++ b/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults.Authorization/Microsoft.Extensions.DependencyInjection/AltinnServiceDefaultsAuthorizationServiceCollectionExtensions.cs
@@ -58,11 +58,7 @@ public static class AltinnServiceDefaultsAuthorizationServiceCollectionExtension
         services.TryAddSingleton<IPlatformAccessTokenSigningKeyProvider, DefaultPlatformAccessTokenSigningKeyProvider>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IAuthorizationHandler, DefaultPlatformAccessTokenHandler>());
 
-#if NET9_0_OR_GREATER
         services.AddHybridCache();
-#else
-        services.AddMemoryCache();
-#endif
 
         services.AddOptions<PlatformAccessTokenKeyVaultSettings>().ValidateDataAnnotations().BindConfiguration("kvSetting");
         services.TryAddKeyedSingleton<TokenCredential>(

--- a/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults.Authorization/Scopes/PlatformAccessToken/ApprovedIssuersCheck.cs
+++ b/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults.Authorization/Scopes/PlatformAccessToken/ApprovedIssuersCheck.cs
@@ -1,10 +1,6 @@
 using System.Runtime.InteropServices;
 
-#if NET9_0_OR_GREATER
 using System.Buffers;
-#else
-using System.Collections.Frozen;
-#endif
 
 namespace Altinn.Authorization.ServiceDefaults.Authorization.Scopes.PlatformAccessToken;
 
@@ -58,12 +54,7 @@ public abstract class ApprovedIssuersCheck
             return AllowAll;
         }
 
-#if NET9_0_OR_GREATER
         return new SearchValueApprovedIssuers(SearchValues.Create(approvedIssuers, StringComparison.Ordinal));
-#else
-        FrozenSet<string> frozenSet = approvedIssuers.ToArray().ToFrozenSet(StringComparer.Ordinal);
-        return new FrozenSetApprovedIssuers(frozenSet);
-#endif
     }
 
     /// <summary>
@@ -86,7 +77,6 @@ public abstract class ApprovedIssuersCheck
         public override bool Check(string issuer) => true;
     }
 
-#if NET9_0_OR_GREATER
 
     private sealed class SearchValueApprovedIssuers
         : ApprovedIssuersCheck
@@ -103,22 +93,4 @@ public abstract class ApprovedIssuersCheck
             => _approvedIssuers.Contains(issuer);
     }
 
-#else
-
-    private sealed class FrozenSetApprovedIssuers
-        : ApprovedIssuersCheck
-    {
-        private readonly FrozenSet<string> _approvedIssuers;
-
-        public FrozenSetApprovedIssuers(FrozenSet<string> approvedIssuers)
-        {
-            _approvedIssuers = approvedIssuers;
-        }
-
-        /// <inheritdoc/>
-        public override bool Check(string issuer)
-            => _approvedIssuers.Contains(issuer);
-    }
-
-#endif
 }

--- a/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults.Authorization/Scopes/PlatformAccessToken/BasePlatformAccessTokenSigningKeyProvider.cs
+++ b/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults.Authorization/Scopes/PlatformAccessToken/BasePlatformAccessTokenSigningKeyProvider.cs
@@ -3,11 +3,7 @@ using Microsoft.IdentityModel.Tokens;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
 
-#if NET9_0_OR_GREATER
 using Microsoft.Extensions.Caching.Hybrid;
-#else
-using Microsoft.Extensions.Caching.Memory;
-#endif
 
 namespace Altinn.Authorization.ServiceDefaults.Authorization.Scopes.PlatformAccessToken;
 
@@ -19,11 +15,7 @@ public abstract class BasePlatformAccessTokenSigningKeyProvider
 {
     private readonly IOptionsMonitor<PlatformAccessTokenSettings> _settings;
 
-#if NET9_0_OR_GREATER
     private readonly HybridCache _cache;
-#else
-    private readonly IMemoryCache _cache;
-#endif
 
     /// <summary>
     /// Initializes a new instance of the BasePlatformAccessTokenSigningKeyProvider class with the specified platform
@@ -31,11 +23,7 @@ public abstract class BasePlatformAccessTokenSigningKeyProvider
     /// </summary>
     protected BasePlatformAccessTokenSigningKeyProvider(
         IOptionsMonitor<PlatformAccessTokenSettings> settings,
-#if NET9_0_OR_GREATER
         HybridCache cache
-#else
-        IMemoryCache cache
-#endif
         )
     {
         _settings = settings;
@@ -51,24 +39,12 @@ public abstract class BasePlatformAccessTokenSigningKeyProvider
         var settings = _settings.CurrentValue;
         string? keyData;
 
-#if NET9_0_OR_GREATER
         keyData = await _cache.GetOrCreateAsync(
             key: cacheKey,
             state: (Self: this, Issuer: issuer),
             factory: (state, cancellationToken) => GetKeyData(state.Self, state.Issuer, cancellationToken),
             options: new HybridCacheEntryOptions { Expiration = TimeSpan.FromSeconds(settings.CacheCertLifetimeInSeconds) },
             cancellationToken: cancellationToken);
-#else
-        if (!_cache.TryGetValue(cacheKey, out keyData))
-        {
-            keyData = await GetKeyData(this, issuer, cancellationToken);
-            using var entry = _cache.CreateEntry(cacheKey);
-            entry
-                .SetPriority(CacheItemPriority.High)
-                .SetAbsoluteExpiration(TimeSpan.FromSeconds(settings.CacheCertLifetimeInSeconds))
-                .SetValue(keyData);
-        }
-#endif
 
         if (string.IsNullOrEmpty(keyData))
         {

--- a/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults.Authorization/Scopes/PlatformAccessToken/DefaultPlatformAccessTokenSigningKeyProvider.cs
+++ b/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults.Authorization/Scopes/PlatformAccessToken/DefaultPlatformAccessTokenSigningKeyProvider.cs
@@ -5,11 +5,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
-#if NET9_0_OR_GREATER
 using Microsoft.Extensions.Caching.Hybrid;
-#else
-using Microsoft.Extensions.Caching.Memory;
-#endif
 
 namespace Altinn.Authorization.ServiceDefaults.Authorization.Scopes.PlatformAccessToken;
 
@@ -22,11 +18,7 @@ internal sealed class DefaultPlatformAccessTokenSigningKeyProvider
     public DefaultPlatformAccessTokenSigningKeyProvider(
         IOptionsMonitor<PlatformAccessTokenSettings> settings,
         [FromKeyedServices(typeof(PlatformAccessTokenSettings))] SecretClient secretClient,
-#if NET9_0_OR_GREATER
         HybridCache cache
-#else
-        IMemoryCache cache
-#endif
         )
         : base(settings, cache)
     {
@@ -40,11 +32,7 @@ internal sealed class DefaultPlatformAccessTokenSigningKeyProvider
         var keyVaultSecret = await _secretClient.GetSecretAsync(secretName, cancellationToken: cancellationToken);
 
         X509Certificate2Collection certs = [];
-#if NET9_0_OR_GREATER
         certs.Add(X509CertificateLoader.LoadCertificate(Convert.FromBase64String(keyVaultSecret.Value.Value)));
-#else
-        certs.Import(Convert.FromBase64String(keyVaultSecret.Value.Value));
-#endif
 
         foreach (var cert in certs)
         {

--- a/src/Altinn.Authorization.ServiceDefaults/test/ServiceDefaults.Authorization.Tests/Altinn.Authorization.ServiceDefaults.Authorization.Tests.csproj
+++ b/src/Altinn.Authorization.ServiceDefaults/test/ServiceDefaults.Authorization.Tests/Altinn.Authorization.ServiceDefaults.Authorization.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <XUnitVersion>v3</XUnitVersion>

--- a/src/Altinn.Authorization.ServiceDefaults/test/ServiceDefaults.Authorization.Tests/Mocks/TestHybridCache.cs
+++ b/src/Altinn.Authorization.ServiceDefaults/test/ServiceDefaults.Authorization.Tests/Mocks/TestHybridCache.cs
@@ -1,4 +1,3 @@
-#if NET9_0_OR_GREATER
 using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Caching.Memory;
 using System.Buffers;
@@ -221,4 +220,3 @@ public sealed class TestHybridCache
         }
     }
 }
-#endif

--- a/src/Altinn.Authorization.ServiceDefaults/test/ServiceDefaults.Authorization.Tests/Mocks/TestPlatformAccessTokenSigningKeyProvider.cs
+++ b/src/Altinn.Authorization.ServiceDefaults/test/ServiceDefaults.Authorization.Tests/Mocks/TestPlatformAccessTokenSigningKeyProvider.cs
@@ -4,11 +4,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Collections.Immutable;
 using System.Security.Cryptography;
 
-#if NET9_0_OR_GREATER
 using Microsoft.Extensions.Caching.Hybrid;
-#else
-using Microsoft.Extensions.Caching.Memory;
-#endif
 
 namespace Altinn.Authorization.ServiceDefaults.Authorization.Tests.Mocks;
 
@@ -20,11 +16,7 @@ internal sealed class TestPlatformAccessTokenSigningKeyProvider
 
     public TestPlatformAccessTokenSigningKeyProvider(
         PlatformAccessTokenSettings settings,
-#if NET9_0_OR_GREATER
         HybridCache cache
-#else
-        IMemoryCache cache
-#endif
         )
         : base(new TestOptionsMonitor<PlatformAccessTokenSettings>(settings), cache)
     {
@@ -33,11 +25,7 @@ internal sealed class TestPlatformAccessTokenSigningKeyProvider
     public TestPlatformAccessTokenSigningKeyProvider()
         : this(
               new PlatformAccessTokenSettings(),
-#if NET9_0_OR_GREATER
               new TestHybridCache()
-#else
-              new MemoryCache(Microsoft.Extensions.Options.Options.Create(new MemoryCacheOptions()))
-#endif
               )
     {
     }

--- a/src/Altinn.Authorization.TestUtils/Directory.Build.props
+++ b/src/Altinn.Authorization.TestUtils/Directory.Build.props
@@ -3,7 +3,7 @@
     Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/Altinn.Authorization.TestUtils/src/TestUtils.AspNetCore/TestClient.cs
+++ b/src/Altinn.Authorization.TestUtils/src/TestUtils.AspNetCore/TestClient.cs
@@ -13,9 +13,6 @@ using System.Text.Encodings.Web;
 
 namespace Altinn.Authorization.TestUtils.AspNetCore;
 
-#if !NET9_0_OR_GREATER
-using Lock = System.Object;
-#endif
 
 /// <summary>
 /// Provides an HTTP client for integration testing ASP.NET Core applications using an in-memory test server. Enables

--- a/src/Altinn.Authorization.TestUtils/src/TestUtils.Http/FakeHttpMessageHandler.cs
+++ b/src/Altinn.Authorization.TestUtils/src/TestUtils.Http/FakeHttpMessageHandler.cs
@@ -5,9 +5,6 @@ using Xunit.Sdk;
 
 namespace Altinn.Authorization.TestUtils.Http;
 
-#if !NET9_0_OR_GREATER
-using Lock = System.Object;
-#endif
 
 /// <summary>
 /// A fake <see cref="HttpMessageHandler"/> that can be used for testing.

--- a/src/Altinn.Authorization.TestUtils/src/TestUtils/Json.cs
+++ b/src/Altinn.Authorization.TestUtils/src/TestUtils/Json.cs
@@ -7,11 +7,7 @@ namespace Altinn.Authorization.TestUtils;
 /// </summary>
 public static class Json
 {
-#if NET9_0_OR_GREATER
     private readonly static JsonSerializerOptions _options = JsonSerializerOptions.Web;
-#else
-    private readonly static JsonSerializerOptions _options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-#endif
 
     /// <summary>
     /// Get the default JSON serializer options used for serialization and deserialization.

--- a/src/Altinn.Authorization.TestUtils/src/TestUtils/Shouldly/ShouldlyJsonExtensions.cs
+++ b/src/Altinn.Authorization.TestUtils/src/TestUtils/Shouldly/ShouldlyJsonExtensions.cs
@@ -505,10 +505,8 @@ public static class ShouldlyJsonExtensions
         private static readonly JsonSerializerOptions _writerOptions
             = new JsonSerializerOptions
             {
-#if NET9_0_OR_GREATER
                 IndentCharacter = ' ',
                 IndentSize = 2,
-#endif
                 WriteIndented = true,
             };
         private static string PrettyPrint(JsonElement element)

--- a/src/Altinn.Urn/src/Altinn.Urn/Altinn.Urn.csproj
+++ b/src/Altinn.Urn/src/Altinn.Urn/Altinn.Urn.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<GenerateNuspecDependsOn>_GetSourceGenerators;$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
 		<PackageDescription>Altinn.Urn is a .NET library designed to simplify working with URNs (Uniform Resource Names) in .NET applications.</PackageDescription>
-		<TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net10.0;net9.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Altinn.Urn/src/Altinn.Urn/UrnEncoded.cs
+++ b/src/Altinn.Urn/src/Altinn.Urn/UrnEncoded.cs
@@ -282,7 +282,6 @@ public sealed class UrnEncoded
         return result;
     }
 
-#if NET9_0_OR_GREATER
     private static void DecodeStringToBuilder(
         scoped ReadOnlySpan<char> stringToUnescape,
         ref ValueStringBuilder vsb)
@@ -313,15 +312,6 @@ public sealed class UrnEncoded
         scratch.Dispose();
         vsb.Advance(written);
     }
-#else
-    private static void DecodeStringToBuilder(
-        scoped ReadOnlySpan<char> stringToUnescape,
-        ref ValueStringBuilder vsb)
-    {
-        var unescaped = Uri.UnescapeDataString(new string(stringToUnescape).Replace('+', ' '));
-        vsb.Append(unescaped);
-    }
-#endif
 
     // Copied from System.UriHelper and removed unused arguments
     private static void EncodeStringToBuilder(

--- a/src/Altinn.Urn/test/Altinn.Urn.SourceGenerator.IntegrationTests/Altinn.Urn.SourceGenerator.IntegrationTests.csproj
+++ b/src/Altinn.Urn/test/Altinn.Urn.SourceGenerator.IntegrationTests/Altinn.Urn.SourceGenerator.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Altinn.Urn/test/Altinn.Urn.SourceGenerator.Tests/Altinn.Urn.SourceGenerator.Tests.csproj
+++ b/src/Altinn.Urn/test/Altinn.Urn.SourceGenerator.Tests/Altinn.Urn.SourceGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>

--- a/src/Altinn.Urn/test/Altinn.Urn.Tests/Altinn.Urn.Tests.csproj
+++ b/src/Altinn.Urn/test/Altinn.Urn.Tests/Altinn.Urn.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net10.0;net9.0</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 	</PropertyGroup>


### PR DESCRIPTION
BREAKING-CHANGE: Removes support for .NET 8 for all packages that still supported it