### PR TITLE
feat: improve error handling using Altinn ProblemDetails

### DIFF
--- a/src/Altinn.Authorization.ServiceDefaults/Altinn.Authorization.ServiceDefaults.sln
+++ b/src/Altinn.Authorization.ServiceDefaults/Altinn.Authorization.ServiceDefaults.sln
@@ -65,6 +65,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.Servic
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.TestUtils.Options", "..\Altinn.Authorization.TestUtils\src\TestUtils.Options\Altinn.Authorization.TestUtils.Options.csproj", "{A2B776E2-509E-4160-A9D4-72CAB665369C}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Altinn.Authorization.ProblemDetails", "Altinn.Authorization.ProblemDetails", "{42CC7F8D-0B27-7E88-0BF9-7453449BDA0E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.ProblemDetails", "..\Altinn.Authorization.ProblemDetails\src\ProblemDetails\Altinn.Authorization.ProblemDetails.csproj", "{4DFCDD22-A3FF-4F9B-97C9-C5AD9D70D3E5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.ProblemDetails.Abstractions", "..\Altinn.Authorization.ProblemDetails\src\ProblemDetails.Abstractions\Altinn.Authorization.ProblemDetails.Abstractions.csproj", "{7215BB06-DB79-48A0-AD2F-D831D3EC7298}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.ProblemDetails.Validation", "..\Altinn.Authorization.ProblemDetails\src\ProblemDetails.Validation\Altinn.Authorization.ProblemDetails.Validation.csproj", "{84DB6521-EC05-447B-848B-CAB6C21AB3F8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -375,6 +383,42 @@ Global
 		{A2B776E2-509E-4160-A9D4-72CAB665369C}.Release|x64.Build.0 = Release|Any CPU
 		{A2B776E2-509E-4160-A9D4-72CAB665369C}.Release|x86.ActiveCfg = Release|Any CPU
 		{A2B776E2-509E-4160-A9D4-72CAB665369C}.Release|x86.Build.0 = Release|Any CPU
+		{4DFCDD22-A3FF-4F9B-97C9-C5AD9D70D3E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4DFCDD22-A3FF-4F9B-97C9-C5AD9D70D3E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4DFCDD22-A3FF-4F9B-97C9-C5AD9D70D3E5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4DFCDD22-A3FF-4F9B-97C9-C5AD9D70D3E5}.Debug|x64.Build.0 = Debug|Any CPU
+		{4DFCDD22-A3FF-4F9B-97C9-C5AD9D70D3E5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4DFCDD22-A3FF-4F9B-97C9-C5AD9D70D3E5}.Debug|x86.Build.0 = Debug|Any CPU
+		{4DFCDD22-A3FF-4F9B-97C9-C5AD9D70D3E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4DFCDD22-A3FF-4F9B-97C9-C5AD9D70D3E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4DFCDD22-A3FF-4F9B-97C9-C5AD9D70D3E5}.Release|x64.ActiveCfg = Release|Any CPU
+		{4DFCDD22-A3FF-4F9B-97C9-C5AD9D70D3E5}.Release|x64.Build.0 = Release|Any CPU
+		{4DFCDD22-A3FF-4F9B-97C9-C5AD9D70D3E5}.Release|x86.ActiveCfg = Release|Any CPU
+		{4DFCDD22-A3FF-4F9B-97C9-C5AD9D70D3E5}.Release|x86.Build.0 = Release|Any CPU
+		{7215BB06-DB79-48A0-AD2F-D831D3EC7298}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7215BB06-DB79-48A0-AD2F-D831D3EC7298}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7215BB06-DB79-48A0-AD2F-D831D3EC7298}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7215BB06-DB79-48A0-AD2F-D831D3EC7298}.Debug|x64.Build.0 = Debug|Any CPU
+		{7215BB06-DB79-48A0-AD2F-D831D3EC7298}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7215BB06-DB79-48A0-AD2F-D831D3EC7298}.Debug|x86.Build.0 = Debug|Any CPU
+		{7215BB06-DB79-48A0-AD2F-D831D3EC7298}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7215BB06-DB79-48A0-AD2F-D831D3EC7298}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7215BB06-DB79-48A0-AD2F-D831D3EC7298}.Release|x64.ActiveCfg = Release|Any CPU
+		{7215BB06-DB79-48A0-AD2F-D831D3EC7298}.Release|x64.Build.0 = Release|Any CPU
+		{7215BB06-DB79-48A0-AD2F-D831D3EC7298}.Release|x86.ActiveCfg = Release|Any CPU
+		{7215BB06-DB79-48A0-AD2F-D831D3EC7298}.Release|x86.Build.0 = Release|Any CPU
+		{84DB6521-EC05-447B-848B-CAB6C21AB3F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84DB6521-EC05-447B-848B-CAB6C21AB3F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84DB6521-EC05-447B-848B-CAB6C21AB3F8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{84DB6521-EC05-447B-848B-CAB6C21AB3F8}.Debug|x64.Build.0 = Debug|Any CPU
+		{84DB6521-EC05-447B-848B-CAB6C21AB3F8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{84DB6521-EC05-447B-848B-CAB6C21AB3F8}.Debug|x86.Build.0 = Debug|Any CPU
+		{84DB6521-EC05-447B-848B-CAB6C21AB3F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84DB6521-EC05-447B-848B-CAB6C21AB3F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{84DB6521-EC05-447B-848B-CAB6C21AB3F8}.Release|x64.ActiveCfg = Release|Any CPU
+		{84DB6521-EC05-447B-848B-CAB6C21AB3F8}.Release|x64.Build.0 = Release|Any CPU
+		{84DB6521-EC05-447B-848B-CAB6C21AB3F8}.Release|x86.ActiveCfg = Release|Any CPU
+		{84DB6521-EC05-447B-848B-CAB6C21AB3F8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -407,6 +451,10 @@ Global
 		{5ED27521-B432-47C8-8ED1-883A23F02BAF} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{32119D20-9994-4128-8908-2AF6036065DF} = {0C88DD14-F956-CE84-757C-A364CCF449FC}
 		{A2B776E2-509E-4160-A9D4-72CAB665369C} = {00E22EFA-B251-4832-5267-0E375C381169}
+		{42CC7F8D-0B27-7E88-0BF9-7453449BDA0E} = {9D04EDA7-9286-9C38-2C42-87A0303CF8B9}
+		{4DFCDD22-A3FF-4F9B-97C9-C5AD9D70D3E5} = {42CC7F8D-0B27-7E88-0BF9-7453449BDA0E}
+		{7215BB06-DB79-48A0-AD2F-D831D3EC7298} = {42CC7F8D-0B27-7E88-0BF9-7453449BDA0E}
+		{84DB6521-EC05-447B-848B-CAB6C21AB3F8} = {42CC7F8D-0B27-7E88-0BF9-7453449BDA0E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D39107E8-3377-44E7-A264-02D857A0AAC5}

--- a/src/Altinn.Authorization.ServiceDefaults/conf.json
+++ b/src/Altinn.Authorization.ServiceDefaults/conf.json
@@ -1,3 +1,7 @@
 {
-  "deps": ["pkg:Altinn.Authorization.TestUtils", "pkg:Altinn.Swashbuckle"]
+  "deps": [
+    "pkg:Altinn.Authorization.TestUtils",
+    "pkg:Altinn.Swashbuckle",
+    "pkg:Altinn.Authorization.ProblemDetails"
+  ]
 }

--- a/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults/Altinn.Authorization.ServiceDefaults.csproj
+++ b/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults/Altinn.Authorization.ServiceDefaults.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../../Altinn.Authorization.ProblemDetails/src/ProblemDetails/Altinn.Authorization.ProblemDetails.csproj" />
     <ProjectReference Include="..\ServiceDefaults.Abstractions\Altinn.Authorization.ServiceDefaults.Abstractions.csproj" />
     <ProjectReference Include="..\ServiceDefaults.Authorization\Altinn.Authorization.ServiceDefaults.Authorization.csproj" />
     <ProjectReference Include="..\ServiceDefaults.Telemetry\Altinn.Authorization.ServiceDefaults.Telemetry.csproj" />

--- a/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults/AltinnExceptionHandler.cs
+++ b/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults/AltinnExceptionHandler.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using Altinn.Authorization.ProblemDetails;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Altinn.Authorization.ServiceDefaults;
+
+internal sealed class AltinnExceptionHandler
+    : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        var problemInstance = TryGetProblemInstance(exception);
+        if (problemInstance is null)
+        {
+            var statusCode = httpContext.Response.StatusCode;
+            if (statusCode < StatusCodes.Status400BadRequest)
+            {
+                statusCode = StatusCodes.Status500InternalServerError;
+            }
+
+            problemInstance = HttpProblemDescriptors.For((HttpStatusCode)statusCode);
+        }
+
+        var problemDetails = problemInstance.ToProblemDetails();
+        var problemDetailsService = httpContext.RequestServices.GetRequiredService<IProblemDetailsService>();
+
+        httpContext.Response.StatusCode = problemDetails.Status ?? StatusCodes.Status500InternalServerError;
+        await problemDetailsService.WriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = httpContext,
+            ProblemDetails = problemDetails,
+            Exception = exception,
+        });
+
+        return true;
+    }
+
+    private static ProblemInstance? TryGetProblemInstance(Exception exception)
+    {
+        foreach (var exn in Chain(exception))
+        {
+            if (exn is AggregateException { InnerExceptions.Count: > 0 } aggregateException)
+            {
+                return TryCollectProblemInstance(aggregateException.InnerExceptions);
+            }
+
+            if (exn is IHasProblem { Problem: { } problem })
+            {
+                return problem;
+            }
+        }
+
+        return null;
+
+        static IEnumerable<Exception> Chain(Exception? exception)
+        {
+            while (exception is not null)
+            {
+                yield return exception;
+                exception = exception.InnerException;
+            }
+        }
+
+        static ProblemInstance? TryCollectProblemInstance(IEnumerable<Exception> exceptions)
+        {
+            MultipleProblemBuilder builder = default;
+
+            foreach (var exn in exceptions)
+            {
+                if (TryGetProblemInstance(exn) is { } problem)
+                {
+                    builder.Add(problem);
+                }
+            }
+
+            if (builder.TryBuild(out var result))
+            {
+                return result;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults/Microsoft.Extensions.Hosting/AltinnServiceDefaultsExtensions.cs
+++ b/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults/Microsoft.Extensions.Hosting/AltinnServiceDefaultsExtensions.cs
@@ -107,6 +107,8 @@ public static class AltinnServiceDefaultsExtensions
         }
 
         builder.Services.AddMetricsProvider();
+        builder.Services.AddAltinnProblemDetails();
+        builder.Services.AddExceptionHandler<AltinnExceptionHandler>();
         builder.Services.AddSingleton<AltinnServiceResourceDetector>();
         builder.Services.AddSingleton<HttpStandardResilienceTelemetry>();
         builder.Services.AddOptions<AltinnClusterInfo>().BindConfiguration("Altinn:ClusterInfo");
@@ -216,9 +218,8 @@ public static class AltinnServiceDefaultsExtensions
     /// Requires that <see cref="AddAltinnServiceDefaults(IHostApplicationBuilder, string, Action{AltinnServiceDefaultOptions})"/> has been called.
     /// </remarks>
     /// <param name="app">The <see cref="WebApplication"/>.</param>
-    /// <param name="errorHandlingPath">The path to use for error handling in production environments.</param>
     /// <returns><paramref name="app"/>.</returns>
-    public static WebApplication AddDefaultAltinnMiddleware(this WebApplication app, string errorHandlingPath)
+    public static WebApplication AddDefaultAltinnMiddleware(this WebApplication app)
     {
         var logger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger(nameof(AltinnServiceDefaultsExtensions));
         var otel = app.Services.GetService<LoggerProvider>()?.GetResource();
@@ -234,7 +235,7 @@ public static class AltinnServiceDefaultsExtensions
         {
             logger.LogInformation("Production => Using exception handler");
 
-            app.UseExceptionHandler(errorHandlingPath);
+            app.UseExceptionHandler();
         }
 
         if (otel is not null)

--- a/src/Altinn.Authorization.ServiceDefaults/test/ServiceDefaults.Tests/Altinn.Authorization.ServiceDefaults.Tests.csproj
+++ b/src/Altinn.Authorization.ServiceDefaults/test/ServiceDefaults.Tests/Altinn.Authorization.ServiceDefaults.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../../Altinn.Authorization.TestUtils/src/TestUtils.AspNetCore/Altinn.Authorization.TestUtils.AspNetCore.csproj" />
     <ProjectReference Include="..\..\..\Altinn.Authorization.TestUtils\src\TestUtils.Http\Altinn.Authorization.TestUtils.Http.csproj" />
     <ProjectReference Include="..\..\..\Altinn.Authorization.TestUtils\src\TestUtils\Altinn.Authorization.TestUtils.csproj" />
     <ProjectReference Include="..\..\src\ServiceDefaults.HttpClient\Altinn.Authorization.ServiceDefaults.HttpClient.csproj" />

--- a/src/Altinn.Authorization.ServiceDefaults/test/ServiceDefaults.Tests/ErrorHandlingTests.cs
+++ b/src/Altinn.Authorization.ServiceDefaults/test/ServiceDefaults.Tests/ErrorHandlingTests.cs
@@ -1,0 +1,245 @@
+using System.Net;
+using System.Text.Json;
+using Altinn.Authorization.ProblemDetails;
+using Altinn.Authorization.TestUtils;
+using Altinn.Authorization.TestUtils.AspNetCore;
+using Altinn.Authorization.TestUtils.Shouldly;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Altinn.Authorization.ServiceDefaults.Tests;
+
+public class ErrorHandlingTests
+    : IAsyncLifetime
+{
+    private TestClient? _client;
+
+    private TestClient Client
+        => _client!;
+
+    private static CancellationToken CancellationToken
+        => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task Controller_Exception_ReturnsProblemDetails()
+    {
+        var response = await Client.GetAsync("/controller/throw-invalid", CancellationToken);
+        await response.ShouldHaveStatusCode(HttpStatusCode.InternalServerError);
+
+        var problem = await response.ShouldHaveJsonContent<AltinnProblemDetails>();
+        problem.ErrorCode.ShouldBe(HttpProblemDescriptors.For(HttpStatusCode.InternalServerError).ErrorCode);
+    }
+
+    [Fact]
+    public async Task Controller_ProblemException_ReturnsProblemDetails()
+    {
+        var response = await Client.GetAsync("/controller/throw-problem", CancellationToken);
+        await response.ShouldHaveStatusCode(HttpStatusCode.NotImplemented);
+
+        var problem = await response.ShouldHaveJsonContent<AltinnProblemDetails>();
+        problem.ErrorCode.ShouldBe(TestErrors.NotImplemented.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Controller_AggregateProblemException_Empty_ReturnsProblemDetails()
+    {
+        var response = await Client.GetAsync("/controller/throw-aggregate-problem/0", CancellationToken);
+        await response.ShouldHaveStatusCode(HttpStatusCode.InternalServerError);
+
+        var problem = await response.ShouldHaveJsonContent<AltinnProblemDetails>();
+        problem.ErrorCode.ShouldBe(HttpProblemDescriptors.For(HttpStatusCode.InternalServerError).ErrorCode);
+    }
+
+    [Fact]
+    public async Task Controller_AggregateProblemException_Single_ReturnsProblemDetails()
+    {
+        var response = await Client.GetAsync("/controller/throw-aggregate-problem/1", CancellationToken);
+        await response.ShouldHaveStatusCode(HttpStatusCode.NotImplemented);
+
+        var problem = await response.ShouldHaveJsonContent<AltinnProblemDetails>();
+        problem.ErrorCode.ShouldBe(TestErrors.NotImplemented.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Controller_AggregateProblemException_Multiple_ReturnsProblemDetails()
+    {
+        var response = await Client.GetAsync("/controller/throw-aggregate-problem/3", CancellationToken);
+        await response.ShouldHaveStatusCode(HttpStatusCode.InternalServerError);
+
+        var problem = await response.ShouldHaveJsonContent<AltinnProblemDetails>();
+        problem.ErrorCode.ShouldBe(StdProblemDescriptors.ErrorCodes.MultipleProblems);
+
+        using var reserialized = Json.SerializeToDocument(problem);
+        var multiProblem = Json.Deserialize<AltinnMultipleProblemDetails>(reserialized);
+
+        multiProblem.ShouldNotBeNull();
+        multiProblem.Problems.ShouldNotBeNull();
+        multiProblem.Problems.Count.ShouldBe(3);
+
+        foreach (var (innerProblem, index) in multiProblem.Problems.Select((p, i) => (p, i)))
+        {
+            innerProblem.ErrorCode.ShouldBe(TestErrors.NotImplemented.ErrorCode);
+            innerProblem.Extensions.ShouldContainKey("n");
+            innerProblem.Extensions["n"].ShouldBeOfType<JsonElement>()
+                .GetString().ShouldBe(index.ToString());
+        }
+    }
+
+    [Fact]
+    public async Task Controller_Problem_ReturnsProblemDetails()
+    {
+        var response = await Client.GetAsync("/controller/problem", CancellationToken);
+        await response.ShouldHaveStatusCode(HttpStatusCode.InternalServerError);
+
+        var problem = await response.ShouldHaveJsonContent<AltinnProblemDetails>();
+        problem.ErrorCode.ShouldBe(TestErrors.InternalServerError.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Minimal_Exception_ReturnsProblemDetails()
+    {
+        var response = await Client.GetAsync("/minimal/throw-invalid", CancellationToken);
+        await response.ShouldHaveStatusCode(HttpStatusCode.InternalServerError);
+
+        var problem = await response.ShouldHaveJsonContent<AltinnProblemDetails>();
+        problem.ErrorCode.ShouldBe(HttpProblemDescriptors.For(HttpStatusCode.InternalServerError).ErrorCode);
+    }
+
+    [Fact]
+    public async Task Minimal_ProblemException_ReturnsProblemDetails()
+    {
+        var response = await Client.GetAsync("/minimal/throw-problem", CancellationToken);
+        await response.ShouldHaveStatusCode(HttpStatusCode.NotImplemented);
+
+        var problem = await response.ShouldHaveJsonContent<AltinnProblemDetails>();
+        problem.ErrorCode.ShouldBe(TestErrors.NotImplemented.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Minimal_Problem_ReturnsProblemDetails()
+    {
+        var response = await Client.GetAsync("/minimal/problem", CancellationToken);
+        await response.ShouldHaveStatusCode(HttpStatusCode.InternalServerError);
+
+        var problem = await response.ShouldHaveJsonContent<AltinnProblemDetails>();
+        problem.ErrorCode.ShouldBe(TestErrors.InternalServerError.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Middleware_Exception_ReturnsProblemDetails()
+    {
+        var response = await Client.GetAsync("/middleware/throw-invalid", CancellationToken);
+        await response.ShouldHaveStatusCode(HttpStatusCode.InternalServerError);
+
+        var problem = await response.ShouldHaveJsonContent<AltinnProblemDetails>();
+        problem.ErrorCode.ShouldBe(HttpProblemDescriptors.For(HttpStatusCode.InternalServerError).ErrorCode);
+    }
+
+    [Fact]
+    public async Task Middleware_ProblemException_ReturnsProblemDetails()
+    {
+        var response = await Client.GetAsync("/middleware/throw-problem", CancellationToken);
+        await response.ShouldHaveStatusCode(HttpStatusCode.NotImplemented);
+
+        var problem = await response.ShouldHaveJsonContent<AltinnProblemDetails>();
+        problem.ErrorCode.ShouldBe(TestErrors.NotImplemented.ErrorCode);
+    }
+
+    ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        IAsyncDisposable? client = Interlocked.Exchange(ref _client, null);
+        if (client is not null)
+        {
+            return client.DisposeAsync();
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    async ValueTask IAsyncLifetime.InitializeAsync()
+    {
+        _client = await TestClient.Create(
+            configureBuilder: builder =>
+            {
+                builder.AddAltinnServiceDefaults("test");
+
+                builder.Services.AddMvc()
+                    .AddTestController<TestController>();
+
+                builder.Services.AddAuthentication("TestClient")
+                    .AddTestAuthentication("TestClient");
+            },
+            configureApplication: app =>
+            {
+                app.AddDefaultAltinnMiddleware();
+                app.Use(async (context, next) =>
+                {
+                    await Task.Yield();
+
+                    if (context.Request.Path == "/middleware/throw-invalid")
+                    {
+                        throw new InvalidOperationException("Test middleware exception");
+                    }
+
+                    if (context.Request.Path == "/middleware/throw-problem")
+                    {
+                        throw TestErrors.NotImplemented.Create().ToException();
+                    }
+
+                    await next(context);
+                });
+
+                app.MapDefaultAltinnEndpoints();
+                app.MapGet("/minimal/throw-invalid", context =>
+                {
+                    throw new InvalidOperationException("Test endpoint exception");
+                });
+                app.MapGet("/minimal/throw-problem", context =>
+                {
+                    throw TestErrors.NotImplemented.Create().ToException();
+                });
+                app.MapGet("/minimal/problem", () =>
+                {
+                    return TypedResults.Problem(TestErrors.InternalServerError.ToProblemDetails(detail: "Test problem detail"));
+                });
+                app.MapControllers();
+            });
+    }
+
+    [ApiController]
+    public sealed class TestController
+        : ControllerBase
+    {
+        [HttpGet("/controller/throw-invalid")]
+        public IActionResult Throw()
+        {
+            throw new InvalidOperationException("Test controller exception");
+        }
+
+        [HttpGet("/controller/throw-problem")]
+        public IActionResult ThrowProblem()
+        {
+            throw TestErrors.NotImplemented.Create().ToException();
+        }
+
+        [HttpGet("/controller/throw-aggregate-problem/{count:int}")]
+        public IActionResult ThrowAggregateProblem(int count)
+        {
+            var problems = Enumerable.Range(0, count)
+                .Select(n => TestErrors.NotImplemented.Create([new("n", n.ToString())]).ToException())
+                .ToArray();
+
+            throw new AggregateException(problems);
+        }
+
+        [HttpGet("/controller/problem")]
+        public IActionResult Problem()
+        {
+            return TestErrors.InternalServerError.ToActionResult(detail: "Test problem detail");
+        }
+    }
+}

--- a/src/Altinn.Authorization.ServiceDefaults/test/ServiceDefaults.Tests/TestErrors.cs
+++ b/src/Altinn.Authorization.ServiceDefaults/test/ServiceDefaults.Tests/TestErrors.cs
@@ -1,0 +1,22 @@
+using System.Net;
+using Altinn.Authorization.ProblemDetails;
+
+namespace Altinn.Authorization.ServiceDefaults.Tests;
+
+internal static class TestErrors
+{
+    private static readonly ProblemDescriptorFactory _factory
+        = ProblemDescriptorFactory.New("TEST");
+
+    public static ProblemDescriptor BadRequest { get; }
+        = _factory.Create(1, HttpStatusCode.BadRequest, "Bad request");
+
+    public static ProblemDescriptor NotFound { get; }
+        = _factory.Create(2, HttpStatusCode.NotFound, "Not found");
+
+    public static ProblemDescriptor InternalServerError { get; }
+        = _factory.Create(3, HttpStatusCode.InternalServerError, "Internal server error");
+
+    public static ProblemDescriptor NotImplemented { get; }
+        = _factory.Create(4, HttpStatusCode.NotImplemented, "Not implemented");
+}


### PR DESCRIPTION
BREAKING-CHANGE: `AddDefaultAltinnMiddleware` no longer uses a error-path. Errors are instead handled directly in `AddAltinnServiceDefaults`/`AltinnHost.CreateWebApplicationBuilder`