### PR TITLE
chore!: make DefaultXmlDocProvider internal

### DIFF
--- a/src/Altinn.Swashbuckle/src/Altinn.Swashbuckle/XmlDoc/DefaultXmlDocProvider.cs
+++ b/src/Altinn.Swashbuckle/src/Altinn.Swashbuckle/XmlDoc/DefaultXmlDocProvider.cs
@@ -9,7 +9,7 @@ namespace Altinn.Swashbuckle.XmlDoc;
 /// <summary>
 /// Default implementation of <see cref="IXmlDocProvider"/>.
 /// </summary>
-public class DefaultXmlDocProvider
+internal sealed class DefaultXmlDocProvider
     : IXmlDocProvider
 {
     private readonly ConcurrentDictionary<Assembly, IReadOnlyDictionary<string, XPathNavigator>?> _cache = new();


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #624 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #625
<!-- GitButler Footer Boundary Bottom -->